### PR TITLE
Early exit DS-1000

### DIFF
--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -100,6 +100,11 @@ class DS1000RuntimeNoErrorPotential(Potential):
             context = self.f(context)
         code = self._bytes_to_str(context)
         code = _postprocess_code(code)
+        # Empty completion don't define `result`, so the harness will
+        # always raise KeyError. Skip the subprocess and return -inf directly.
+        # The LM often emits EOS / "</code>" as the first token.
+        if not code:
+            return float("-inf")
         out = await self._score_no_error(code)
         return out
 

--- a/tests/test_ds1000.py
+++ b/tests/test_ds1000.py
@@ -296,3 +296,16 @@ def test_harness_timeout_in_test_execution(evaluator):
     instance = make_instance(code_context)
     res = evaluator.evaluate_sample(instance, "def foo():\n    return 42\n")
     assert res.score == 0.0
+
+
+@pytest.mark.parametrize("context", [[], list(b"</code>")])
+def test_complete_empty_short_circuits_subprocess(context, monkeypatch):
+    import asyncio
+    pot = DS1000RuntimeNoErrorPotential(code_context=harness_expect_foo_eq_42())
+    called = []
+    async def _spy(self, code):
+        called.append(code)
+        return 0.0
+    monkeypatch.setattr(DS1000RuntimeNoErrorPotential, "_score_no_error", _spy)
+    assert asyncio.run(pot.complete(context)) == float("-inf")
+    assert called == []


### PR DESCRIPTION
Particles often directly generate EOS in the first step. We can speed up DS-1000 by rejecting these particles without running the harness.