### PR TITLE
Refactor subprocess

### DIFF
--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -1,45 +1,40 @@
-from typing import Callable, Dict, List, Optional
+import ast
 import asyncio
-from collections import OrderedDict
-import tempfile
-import subprocess
-import sys
-import textwrap
+import multiprocessing as mp
 import os
+import sys
+import threading
+from collections import OrderedDict
+from typing import Any, Callable, Dict, List, Optional
 
 from genlm.control import Potential
-from genlm.eval.domains.ds1000.utils import _postprocess_code, _sandbox_env
+from genlm.eval.domains.ds1000.utils import _postprocess_code
 
 
 class DS1000RuntimeNoErrorPotential(Potential):
-    """
-    DS-1000 expensive potential: execute the harness on a complete prefix.
-    Return 0.0 if no error, -inf otherwise.
-    """
+    """DS-1000 expensive potential: 0.0 if no runtime error, -inf otherwise."""
+
+    _score_cache_maxsize = 4096
 
     def __init__(
         self,
         vocabulary=None,
         code_context: str = "",
         timeout_seconds: float = 30.0,
-        python_executable: Optional[str] = None,
-        extra_env: Optional[Dict[str, str]] = None,
         f: Optional[Callable[[List[bytes]], List[bytes]]] = None,
+        # Legacy args -- still accepted by callers, ignored by the fork runner.
+        python_executable: Optional[str] = None,  # noqa: ARG002
+        extra_env: Optional[Dict[str, Any]] = None,  # noqa: ARG002
     ):
         vocabulary = vocabulary or [bytes([i]) for i in range(256)]
         super().__init__(vocabulary=vocabulary)
         self.timeout_seconds = float(timeout_seconds)
         self.code_context = code_context
-        self.python_executable = python_executable or sys.executable
-        self.extra_env = dict(extra_env or {})
         self.last_was_syntax_error = False
         self.f = f
-        # SMC frequently clones particles into identical or repeated prefixes.
-        # Cache exact postprocessed code strings to avoid launching duplicate
-        # DS1000 subprocess checks. The cache is per potential instance, whose
-        # code_context / timeout / environment are fixed.
-        self._score_cache = OrderedDict()
-        self._score_cache_maxsize = 4096
+        # Cache exact postprocessed code strings -- SMC clones often produce
+        # identical prefixes.
+        self._score_cache: "OrderedDict[str, tuple[float, bool]]" = OrderedDict()
         self.cache_hits = 0
         self.cache_misses = 0
 
@@ -53,8 +48,6 @@ class DS1000RuntimeNoErrorPotential(Potential):
             vocabulary=list(other.vocab),
             code_context=self.code_context,
             timeout_seconds=self.timeout_seconds,
-            python_executable=self.python_executable,
-            extra_env=self.extra_env,
             f=f,
         )
 
@@ -65,58 +58,41 @@ class DS1000RuntimeNoErrorPotential(Potential):
             return toks
         if isinstance(toks, bytes):
             return toks.decode("utf-8", errors="ignore")
-        # genlm-control/vLLM contexts may be either byte tokens or integer byte ids.
-        # Normalize both forms before decoding so the potential is robust across
-        # backend/token-map representations.
-        byte_pieces = []
+        # Token lists may be int byte-ids or bytes; normalize before joining.
+        pieces = []
         for tok in toks:
             if isinstance(tok, int):
-                byte_pieces.append(bytes([tok]))
+                pieces.append(bytes([tok]))
             elif isinstance(tok, bytes):
-                byte_pieces.append(tok)
+                pieces.append(tok)
             else:
-                byte_pieces.append(str(tok).encode("utf-8", errors="ignore"))
-        raw = b"".join(byte_pieces)
+                pieces.append(str(tok).encode("utf-8", errors="ignore"))
+        raw = b"".join(pieces)
         try:
-            bytes_str = raw.decode("utf-8", errors="ignore")
+            return raw.decode("utf-8", errors="ignore")
         except UnicodeDecodeError:
-            bytes_str = raw.decode("latin-1", errors="ignore")
-        return bytes_str
+            return raw.decode("latin-1", errors="ignore")
 
     async def prefix(self, context: List[bytes]) -> float:
         if self.f is not None:
             context = self.f(context)
         code = self._bytes_to_str(context)
-        # Newline guardrail when using the default sampler.
+        # Newline guardrail: only score complete lines.
         if not code.endswith("\n"):
             return 0.0
-        code = _postprocess_code(code)
-        out = await self._score_no_error(code)
-        return out
+        return await self._score_no_error(_postprocess_code(code))
 
     async def complete(self, context: List[bytes]):
-        # Apply transformation before processing
         if self.f is not None:
             context = self.f(context)
-        code = self._bytes_to_str(context)
-        code = _postprocess_code(code)
-        # Empty completion don't define `result`, so the harness will
-        # always raise KeyError. Skip the subprocess and return -inf directly.
-        # The LM often emits EOS / "</code>" as the first token.
+        code = _postprocess_code(self._bytes_to_str(context))
+        # Empty completion never defines ``result``; short-circuit.
         if not code:
             return float("-inf")
-        out = await self._score_no_error(code)
-        return out
+        return await self._score_no_error(code)
 
     async def _score_no_error(self, complete_code: str) -> float:
-        """
-        Run the harness script in a subprocess and check for runtime errors.
-        Returns 0.0 if no error (incl. AssertionError), -inf otherwise.
-
-        complete_code: str - the complete code to run
-        Returns:
-            float - 0.0 if no error, -inf otherwise.
-        """
+        """0.0 if the candidate runs without error (AssertionError == OK), else -inf."""
         cached = self._score_cache.get(complete_code)
         if cached is not None:
             self._score_cache.move_to_end(complete_code)
@@ -126,93 +102,98 @@ class DS1000RuntimeNoErrorPotential(Potential):
             return value
         self.cache_misses += 1
 
-        OK, BAD, SYNTAX = "<<<OK>>>", "<<<BAD>>>", "<<<SYNTAX>>>"
-
-        script = textwrap.dedent(
-            f"""
-            import sys, warnings, os, ast
-            warnings.filterwarnings("ignore")
-            os.environ.setdefault("PYTHONWARNINGS", "ignore")
-            os.environ.setdefault("MPLBACKEND", "Agg")
-
-            OK, BAD, SYNTAX = "<<<OK>>>", "<<<BAD>>>", "<<<SYNTAX>>>"
-            code_context = {self.code_context!r}
-            answer = {complete_code!r}
-            try:
-                g = {{}}
-                exec(code_context, g, g)
-                te = g.get("test_execution")
-                if not callable(te):
-                    print(BAD); raise SystemExit(0)
-                try: # ast.parse to check if the answer is valid code
-                    ast.parse(answer, filename="<answer>", mode="exec")
-                except SyntaxError:
-                    print(SYNTAX); raise SystemExit(0)
-                try:
-                    te(answer)
-                    # If we get here with no exception, it ran without runtime error.
-                    print(OK)
-                except AssertionError:
-                    print(OK)
-                except SyntaxError:
-                    print(SYNTAX)
-                except Exception:
-                    print(BAD)
-            except AssertionError: # Safety check for AssertionError
-                print(OK)
-            except SyntaxError:
-                print(SYNTAX)
-            except Exception:
-                print(BAD)
-            """
-        ).strip()
-
-        try:
-            with tempfile.TemporaryDirectory(prefix="ds1000_rt_") as td:
-                path = os.path.join(td, "rt_harness.py")
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(script + "\n")
-
-                env = _sandbox_env(
-                    td,
-                    extra_env={
-                        **{"MPLBACKEND": "Agg", "PYTHONWARNINGS": "ignore"},
-                        **self.extra_env,
-                    },
-                )
-
-                proc = await asyncio.create_subprocess_exec(
-                    self.python_executable,
-                    "-B",
-                    path,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=env,
-                    cwd=td,
-                )
-                try:
-                    stdout_b, stderr_b = await asyncio.wait_for(
-                        proc.communicate(), timeout=self.timeout_seconds
-                    )
-                except asyncio.TimeoutError:
-                    proc.kill()
-                    await proc.communicate()
-                    return float("-inf")
-        except subprocess.TimeoutExpired:
-            return float("-inf")
-
-        out = stdout_b.decode("utf-8", errors="replace") + stderr_b.decode(
-            "utf-8", errors="replace"
-        )
-        ok = any(line.strip() == OK for line in out.splitlines())
-        bad = any(line.strip() == BAD for line in out.splitlines())
-        syntax = any(line.strip() == SYNTAX for line in out.splitlines())
-
+        result = await _fork_score(self.code_context, complete_code, self.timeout_seconds)
+        ok, bad, syntax = (result == _OK), (result == _BAD), (result == _SYN)
         self.last_was_syntax_error = bool(syntax)
-        bad = bad or syntax
-        value = 0.0 if ok and not bad else float("-inf")
+        value = 0.0 if (ok and not (bad or syntax)) else float("-inf")
         self._score_cache[complete_code] = (value, self.last_was_syntax_error)
         self._score_cache.move_to_end(complete_code)
         if len(self._score_cache) > self._score_cache_maxsize:
             self._score_cache.popitem(last=False)
         return value
+
+
+# --- fork-per-request critic backend (parent pre-warms, child runs isolated) -
+
+_CTX = mp.get_context("fork")
+_WARM_LOCK = threading.Lock()
+_WARMED = False
+
+_OK, _BAD, _SYN = "OK", "BAD", "SYN"
+
+
+def _warm() -> None:
+    for mod in ("numpy", "pandas", "scipy", "sklearn", "matplotlib"):
+        try:
+            __import__(mod)
+        except Exception:
+            pass
+
+
+def _ensure_warm() -> None:
+    global _WARMED
+    if _WARMED:
+        return
+    with _WARM_LOCK:
+        if not _WARMED:
+            _warm()
+            _WARMED = True
+
+
+def _child_score(code_context: str, answer: str, conn) -> None:
+    """Run inside the forked child; send the verdict back over ``conn``."""
+    sys.stdout = sys.stderr = open(os.devnull, "w")  # don't leak candidate prints
+    try:
+        g: dict = {}
+        exec(code_context, g, g)
+        te = g.get("test_execution")
+        if not callable(te):
+            conn.send(_BAD); return
+        try:
+            ast.parse(answer, filename="<answer>", mode="exec")
+        except SyntaxError:
+            conn.send(_SYN); return
+        try:
+            te(answer); conn.send(_OK)
+        except AssertionError:
+            conn.send(_OK)
+        except SyntaxError:
+            conn.send(_SYN)
+        except Exception:
+            conn.send(_BAD)
+    except AssertionError:
+        conn.send(_OK)
+    except SyntaxError:
+        conn.send(_SYN)
+    except Exception:
+        conn.send(_BAD)
+    finally:
+        conn.close()
+
+
+def _fork_score_sync(code_context: str, answer: str, timeout: float) -> Optional[str]:
+    """Fork a child, score, return its verdict or ``None`` on timeout/failure."""
+    _ensure_warm()
+    parent, child = _CTX.Pipe(duplex=False)
+    p = _CTX.Process(target=_child_score, args=(code_context, answer, child), daemon=True)
+    p.start()
+    child.close()
+    try:
+        if not parent.poll(timeout):
+            p.kill(); p.join(0.5)
+            return None
+        return parent.recv()
+    except (EOFError, OSError):
+        return None
+    finally:
+        parent.close()
+        if p.is_alive():
+            p.kill()
+        p.join(0.5)
+
+
+async def _fork_score(code_context: str, answer: str, timeout: float) -> Optional[str]:
+    """Async wrapper for :func:`_fork_score_sync` (dispatched off the event loop)."""
+    return await asyncio.get_running_loop().run_in_executor(
+        None, _fork_score_sync, code_context, answer, timeout,
+    )

--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -148,13 +148,16 @@ def _child_score(code_context: str, answer: str, conn) -> None:
         exec(code_context, g, g)
         te = g.get("test_execution")
         if not callable(te):
-            conn.send(_BAD); return
+            conn.send(_BAD)
+            return
         try:
             ast.parse(answer, filename="<answer>", mode="exec")
         except SyntaxError:
-            conn.send(_SYN); return
+            conn.send(_SYN)
+            return
         try:
-            te(answer); conn.send(_OK)
+            te(answer)
+            conn.send(_OK)
         except AssertionError:
             conn.send(_OK)
         except SyntaxError:
@@ -180,7 +183,8 @@ def _fork_score_sync(code_context: str, answer: str, timeout: float) -> Optional
     child.close()
     try:
         if not parent.poll(timeout):
-            p.kill(); p.join(0.5)
+            p.kill()
+            p.join(0.5)
             return None
         return parent.recv()
     except (EOFError, OSError):

--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -103,6 +103,10 @@ class DS1000RuntimeNoErrorPotential(Potential):
         self.cache_misses += 1
 
         result = await _fork_score(self.code_context, complete_code, self.timeout_seconds)
+        if result is None:
+            # Timeout / dead worker: don't cache, the same code may succeed next time.
+            self.last_was_syntax_error = False
+            return float("-inf")
         ok, bad, syntax = (result == _OK), (result == _BAD), (result == _SYN)
         self.last_was_syntax_error = bool(syntax)
         value = 0.0 if (ok and not (bad or syntax)) else float("-inf")

--- a/tests/test_ds1000_fork_runner.py
+++ b/tests/test_ds1000_fork_runner.py
@@ -1,0 +1,94 @@
+"""Unit tests for DS-1000's fork-per-request critic backend."""
+
+import asyncio
+import time
+
+from genlm.eval.domains.ds1000.runtime_no_error_potential import _fork_score
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+CTX = """
+def test_execution(answer):
+    g = {}
+    exec(answer, g, g)
+    assert g.get('x') == 7
+"""
+
+CTX_NO_TE = "y = 1"
+
+CTX_TE_RAISES = """
+def test_execution(answer):
+    raise ValueError("boom")
+"""
+
+
+def test_ok():
+    assert _run(_fork_score(CTX, "x = 7", 10.0)) == "OK"
+
+
+def test_assertion_error_counts_as_ok():
+    # te()'s assert fails (x=8); DS-1000 convention treats this as OK.
+    assert _run(_fork_score(CTX, "x = 8", 10.0)) == "OK"
+
+
+def test_runtime_error_returns_bad():
+    assert _run(_fork_score(CTX, "raise RuntimeError('z')", 10.0)) == "BAD"
+
+
+def test_syntax_error_returns_syn():
+    assert _run(_fork_score(CTX, "x = (((", 10.0)) == "SYN"
+
+
+def test_missing_test_execution_returns_bad():
+    assert _run(_fork_score(CTX_NO_TE, "x = 7", 10.0)) == "BAD"
+
+
+def test_te_non_assertion_exception_returns_bad():
+    assert _run(_fork_score(CTX_TE_RAISES, "x = 7", 10.0)) == "BAD"
+
+
+def test_timeout_returns_none_and_kills_child():
+    t0 = time.perf_counter()
+    result = _run(_fork_score(CTX, "while True: pass", 0.5))
+    assert result is None
+    assert time.perf_counter() - t0 < 5.0  # killed promptly, didn't hang
+
+
+def test_state_isolation_between_calls():
+    """Call K's module-level mutations must not leak into call K+1."""
+    # seed(0)'s first np.random.random() is ~0.5488; if it leaked, call 2 would see it.
+    ctx = """
+import numpy as np
+def test_execution(answer):
+    g = {}
+    exec(answer, g, g)
+    assert abs(float(np.random.random()) - 0.5488135) > 1e-6
+"""
+    assert _run(_fork_score(ctx, "import numpy as np; np.random.seed(0)", 10.0)) == "OK"
+    assert _run(_fork_score(ctx, "pass", 10.0)) == "OK"
+
+
+def test_child_stdout_does_not_leak(capfd):
+    """A candidate's prints must not leak into the parent's stdout/stderr."""
+    _run(_fork_score(CTX, "print('HELLO_FROM_CHILD'); x = 7", 10.0))
+    out, err = capfd.readouterr()
+    assert "HELLO_FROM_CHILD" not in out
+    assert "HELLO_FROM_CHILD" not in err
+
+
+def test_concurrent_dispatch():
+    async def go():
+        return await asyncio.gather(
+            _fork_score(CTX, "x = 7", 10.0),
+            _fork_score(CTX, "x = 8", 10.0),
+            _fork_score(CTX, "x = (((", 10.0),
+            _fork_score(CTX, "raise RuntimeError('z')", 10.0),
+        )
+    assert _run(go()) == ["OK", "OK", "SYN", "BAD"]

--- a/tests/test_ds1000_runtime_potential.py
+++ b/tests/test_ds1000_runtime_potential.py
@@ -1,0 +1,125 @@
+"""Unit tests for DS1000RuntimeNoErrorPotential wrapper logic."""
+
+import asyncio
+
+from genlm.eval.domains.ds1000.runtime_no_error_potential import (
+    DS1000RuntimeNoErrorPotential,
+)
+
+
+CTX = """
+def test_execution(answer):
+    g = {}
+    exec(answer, g, g)
+    assert g.get('x') == 7
+"""
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _bytes(s: str) -> list[bytes]:
+    return [bytes([b]) for b in s.encode()]
+
+
+def test_complete_ok_returns_zero():
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    assert _run(p.complete(_bytes("x = 7"))) == 0.0
+
+
+def test_complete_bad_returns_neg_inf():
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    assert _run(p.complete(_bytes("raise RuntimeError('z')"))) == float("-inf")
+
+
+def test_complete_empty_short_circuits_to_neg_inf():
+    # Empty code never reaches the forked child (fast-path guard).
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    assert _run(p.complete([])) == float("-inf")
+    assert p.cache_misses == 0  # didn't even hit the runner
+
+
+def test_prefix_not_newline_terminated_returns_zero():
+    # Newline guardrail: incomplete code lines are skipped.
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    assert _run(p.prefix(_bytes("x = 7"))) == 0.0  # no trailing \n
+    assert p.cache_misses == 0
+
+
+def test_cache_hit_avoids_running():
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    _run(p.complete(_bytes("x = 7")))
+    _run(p.complete(_bytes("x = 7")))
+    assert p.cache_misses == 1
+    assert p.cache_hits == 1
+
+
+def test_syntax_error_sets_flag():
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    _run(p.complete(_bytes("x = (((")))
+    assert p.last_was_syntax_error is True
+
+
+def test_legacy_kwargs_accepted():
+    # python_executable / extra_env are no-ops but must not raise (holdout passes them).
+    DS1000RuntimeNoErrorPotential(
+        code_context=CTX,
+        python_executable="python3",
+        extra_env={"PYTHONHASHSEED": "0"},
+    )
+
+
+def test_coerce_inherits_config():
+    """coerce() returns a fresh instance with the same context + timeout."""
+    class _Other:
+        vocab = [bytes([i]) for i in range(256)]
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=7.5)
+    q = p.coerce(_Other())
+    assert q.code_context == CTX
+    assert q.timeout_seconds == 7.5
+    assert q is not p
+
+
+def test_prefix_with_newline_invokes_scorer():
+    """A newline-terminated prefix runs the full scoring path (not the guardrail)."""
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    assert _run(p.prefix(_bytes("x = 7\n"))) == 0.0
+    assert p.cache_misses == 1
+
+
+def test_bytes_to_str_input_shapes():
+    """Cover all input-type branches: str, bytes, list[int], list[bytes], list[other]."""
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX)
+    assert p._bytes_to_str("abc") == "abc"
+    assert p._bytes_to_str(b"abc") == "abc"
+    assert p._bytes_to_str([ord("a"), ord("b")]) == "ab"
+    assert p._bytes_to_str([b"a", b"b"]) == "ab"
+    assert p._bytes_to_str([]) == ""
+    assert p._bytes_to_str(["a", "b"]) == "ab"  # generic str fallback
+
+
+def test_f_transform_is_applied():
+    """If ``f`` is given, both prefix() and complete() route context through it."""
+    seen = []
+    def my_f(ctx):
+        seen.append("called")
+        return ctx
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0, f=my_f)
+    _run(p.complete(_bytes("x = 7")))
+    _run(p.prefix(_bytes("x = 7\n")))
+    assert len(seen) == 2
+
+
+def test_cache_evicts_oldest_when_full():
+    """LRU cache must evict when it exceeds ``_score_cache_maxsize``."""
+    p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)
+    p._score_cache_maxsize = 2
+    _run(p.complete(_bytes("x = 7")))
+    _run(p.complete(_bytes("x = 8")))
+    _run(p.complete(_bytes("x = 9")))
+    assert len(p._score_cache) == 2

--- a/tests/test_ds1000_runtime_potential.py
+++ b/tests/test_ds1000_runtime_potential.py
@@ -115,6 +115,14 @@ def test_f_transform_is_applied():
     assert len(seen) == 2
 
 
+def test_timeout_is_not_cached():
+    """Timeouts are transient; the verdict must NOT be cached."""
+    ctx = "def test_execution(answer):\n    while True:\n        pass\n"
+    p = DS1000RuntimeNoErrorPotential(code_context=ctx, timeout_seconds=0.3)
+    assert _run(p.complete(_bytes("x = 1"))) == float("-inf")
+    assert len(p._score_cache) == 0
+
+
 def test_cache_evicts_oldest_when_full():
     """LRU cache must evict when it exceeds ``_score_cache_maxsize``."""
     p = DS1000RuntimeNoErrorPotential(code_context=CTX, timeout_seconds=10.0)


### PR DESCRIPTION
The runtime critic was spawning a fresh `python -B` per call. Replaced with a forked child from the pre-warmed parent process.