### PR TITLE
Remove .strip() from prompt.

### DIFF
--- a/genlm/eval/domains/ds1000/ds1000.py
+++ b/genlm/eval/domains/ds1000/ds1000.py
@@ -40,7 +40,7 @@ class DS1000Dataset(Dataset[DS1000Instance]):
     def __iter__(self) -> Iterator[DS1000Instance]:
         for i, row in enumerate(self._rows):
             yield DS1000Instance(
-                prompt=str(row.get("prompt", "")).strip(),
+                prompt=str(row.get("prompt", "")),
                 code_context=str(row.get("code_context", "")).strip(),
                 reference_code=row.get("reference_code"),
                 metadata=(row.get("metadata") or {}),

--- a/tests/test_ds1000.py
+++ b/tests/test_ds1000.py
@@ -64,7 +64,7 @@ def test_dataset():
     assert len(ds) == 2
     assert ds.schema is DS1000Instance
     items = list(iter(ds))
-    assert items[0].prompt == "P1"
+    assert items[0].prompt == "P1 "  # prompt is kept verbatim
     assert items[0].code_context == "C1"
     assert items[0].metadata["library"] == "pandas"
     assert items[0].reference_code == "print('ok')"


### PR DESCRIPTION
DS1000Dataset called .strip() on each prompt, removing the trailing newline. Matplotlib prompts end in # SOLUTION START\n; without the newline, the model continues the comment.