### PR TITLE
New Runtime potential

### DIFF
--- a/genlm/eval/domains/ds1000/_forkserver_worker.py
+++ b/genlm/eval/domains/ds1000/_forkserver_worker.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
 """
 Warm fork-server for DS-1000 harness scripts: pre-imports the science libs
-(tensorflow excluded, fork-unsafe), forks an isolated child per request.
-Session requests keep a per-task child alive past setup and fork checks from
-it, serialized per task; session failures run the request's fallback script.
-
-JSON lines, stdin -> stdout {"id", "out"}; {"ready": true} after warmup.
-plain: {"id", "script", "timeout"}; session: {"id", "skey", "setup", "body",
-"fallback", "timeout"}. Worker timeout/crash verdicts end with an id-stamped
+(tensorflow excluded, fork-unsafe), forks an isolated child per request, and
+serves session requests from a warm per-task child (fallback script on
+failure). JSON lines in/out; timeout/crash verdicts end with an id-stamped
 "<<<WORKER <id> ...>>>" line.
 """
 

--- a/genlm/eval/domains/ds1000/_forkserver_worker.py
+++ b/genlm/eval/domains/ds1000/_forkserver_worker.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 """
 Warm fork-server for DS-1000 harness scripts: pre-imports the science libs
-(tensorflow excluded, fork-unsafe), forks an isolated child per request, and
-serves session requests from a warm per-task child (fallback script on
-failure). JSON lines in/out; timeout/crash verdicts end with an id-stamped
-"<<<WORKER <id> ...>>>" line.
+(not tensorflow, fork-unsafe) and forks a child per request, or from a warm
+per-task session child. JSON lines in/out.
 """
 
 import json

--- a/genlm/eval/domains/ds1000/_forkserver_worker.py
+++ b/genlm/eval/domains/ds1000/_forkserver_worker.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python
+"""
+Warm fork-server for DS-1000 harness scripts: pre-imports the science
+libraries once, then forks an isolated child per request (own tempdir cwd,
+redirected output, alarm timeout). tensorflow is not pre-imported
+(fork-unsafe).
+
+Sessioned requests additionally keep a per-task child alive that has already
+executed the task's setup (code_context + test-input generation); each check
+forks from it and runs only the solution statements. Session checks are
+serialized per task; on any session failure the request's fallback script
+runs through the plain path.
+
+Protocol (JSON lines on stdin -> stdout {"id", "out"}):
+  plain:    {"id", "script", "timeout"}
+  session:  {"id", "skey", "setup", "body", "fallback", "timeout"}
+{"ready": true} once after warmup. On timeout/crash, "out" ends with
+"<<<TIMEOUT>>>" or "<<<CHILD_EXIT n>>>".
+"""
+
+import json
+import os
+import time
+import select
+import shutil
+import signal
+import sys
+import tempfile
+import traceback
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+os.environ.setdefault("PYTHONWARNINGS", "ignore")
+# Pin BLAS/OpenMP pools to one thread before importing: children inherit only
+# the forking thread, so multi-thread pools can deadlock post-fork.
+for _var in ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS", "MKL_NUM_THREADS",
+             "NUMEXPR_NUM_THREADS"):
+    os.environ.setdefault(_var, "1")
+
+_PRELOAD = os.environ.get(
+    "DS1000_FORKSERVER_PRELOAD",
+    "numpy,pandas,scipy,matplotlib,matplotlib.pyplot,PIL.Image,seaborn,"
+    "sklearn,sklearn.preprocessing,torch",
+)
+for _mod in filter(None, _PRELOAD.split(",")):
+    try:
+        __import__(_mod)
+    except Exception:  # noqa: BLE001
+        pass
+
+try:
+    import torch
+
+    torch.set_num_threads(1)
+except Exception:  # noqa: BLE001
+    pass
+
+# Backstop against fork-bombing if a client ever pipelines more requests than
+# its own concurrency gate allows.
+MAX_CHILDREN = int(os.environ.get("DS1000_FORKSERVER_MAX_CHILDREN", "64"))
+MAX_SESSIONS = int(os.environ.get("DS1000_FORKSERVER_MAX_SESSIONS", "64"))
+SETUP_TIMEOUT = int(os.environ.get("DS1000_FORKSERVER_SETUP_TIMEOUT", "120"))
+
+
+def _sandbox_into(td):
+    os.chdir(td)
+    os.environ.update(
+        {
+            "MPLBACKEND": "Agg",
+            "MPLCONFIGDIR": td,
+            "XDG_CACHE_HOME": os.path.join(td, "xdg_cache"),
+            "XDG_CONFIG_HOME": os.path.join(td, "xdg_config"),
+            "PYTHONWARNINGS": "ignore",
+        }
+    )
+
+
+def run_child(script: str, timeout: float, out_path: str, td: str) -> None:
+    """Executed in the forked child. Never returns."""
+    rc = 0
+    try:
+        fd = os.open(out_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.dup2(fd, 1)
+        os.dup2(fd, 2)
+        os.close(fd)
+        _sandbox_into(td)
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+        signal.alarm(max(1, int(timeout)))
+        g = {"__name__": "__main__", "__builtins__": __builtins__}
+        try:
+            exec(compile(script, "<harness>", "exec"), g, g)
+        except SystemExit:
+            pass
+        except BaseException:  # noqa: BLE001
+            traceback.print_exc()
+            rc = 1
+    except BaseException:  # noqa: BLE001
+        rc = 2
+    finally:
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:  # noqa: BLE001
+            pass
+        os._exit(rc)
+
+
+def run_session(setup: str, cmd_r: int, res_w: int, td: str) -> None:
+    """Session child: run setup once, then fork one grandchild per body."""
+
+    def send(obj):
+        os.write(res_w, (json.dumps(obj) + "\n").encode())
+
+    try:
+        os.setsid()
+        log_fd = os.open(os.path.join(td, "__session__.log"),
+                         os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.dup2(log_fd, 1)
+        os.dup2(log_fd, 2)
+        os.close(log_fd)
+        _sandbox_into(td)
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+        signal.alarm(SETUP_TIMEOUT)
+        ns = {"__name__": "__main__", "__builtins__": __builtins__}
+        try:
+            exec(compile(setup, "<session-setup>", "exec"), ns, ns)
+        except BaseException:  # noqa: BLE001
+            traceback.print_exc()
+            send({"setup_failed": 1})
+            os._exit(0)
+        signal.alarm(0)
+        send({"ready": 1})
+
+        buf = b""
+        while True:
+            chunk = os.read(cmd_r, 1 << 20)
+            if not chunk:
+                os._exit(0)
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                req = json.loads(line)
+                sys.stdout.flush()
+                sys.stderr.flush()
+                try:
+                    pid = os.fork()
+                except OSError:
+                    send({"id": req["id"], "forkfail": 1})
+                    continue
+                if pid == 0:
+                    os.close(cmd_r)
+                    os.close(res_w)
+                    run_child_in_ns(req["body"], req["timeout"], req["out"], ns)
+                _, status = os.waitpid(pid, 0)
+                send({"id": req["id"], "status": status})
+    except BaseException:  # noqa: BLE001
+        try:
+            send({"setup_failed": 1})
+        except Exception:  # noqa: BLE001
+            pass
+        os._exit(2)
+
+
+def run_child_in_ns(body: str, timeout: float, out_path: str, ns) -> None:
+    """Grandchild: execute a body script in the session namespace."""
+    rc = 0
+    try:
+        fd = os.open(out_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.dup2(fd, 1)
+        os.dup2(fd, 2)
+        os.close(fd)
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+        signal.alarm(max(1, int(timeout)))
+        try:
+            exec(compile(body, "<harness-body>", "exec"), ns, ns)
+        except SystemExit:
+            pass
+        except BaseException:  # noqa: BLE001
+            traceback.print_exc()
+            rc = 1
+    except BaseException:  # noqa: BLE001
+        rc = 2
+    finally:
+        try:
+            sys.stdout.flush()
+            sys.stderr.flush()
+        except Exception:  # noqa: BLE001
+            pass
+        os._exit(rc)
+
+
+def _read_out(out_path):
+    try:
+        with open(out_path, "r", errors="replace") as fh:
+            out = fh.read()
+    except OSError:
+        out = ""
+    # Solutions may print huge arrays; markers are emitted at the end, so
+    # keep the head for context and the full tail.
+    if len(out) > 100_000:
+        out = out[:8_000] + "\n<<<TRUNCATED>>>\n" + out[-64_000:]
+    return out
+
+
+def _suffix_for_status(status, req_id):
+    """Worker verdict suffix, id-stamped so solution prints cannot spoof it."""
+    if os.WIFSIGNALED(status) and os.WTERMSIG(status) == signal.SIGALRM:
+        return f"\n<<<WORKER {req_id} TIMEOUT>>>"
+    if os.WIFSIGNALED(status):
+        return f"\n<<<WORKER {req_id} CHILD_EXIT -{os.WTERMSIG(status)}>>>"
+    if os.WEXITSTATUS(status) == 2:
+        return f"\n<<<WORKER {req_id} CHILD_EXIT 2>>>"
+    return ""
+
+
+def main() -> None:
+    children = {}  # pid -> (req_id, out_path, td, deadline)
+    sessions = {}  # skey -> session dict
+    session_pids = {}  # pid -> skey
+
+    def respond(req_id, out):
+        sys.stdout.write(json.dumps({"id": req_id, "out": out}) + "\n")
+        sys.stdout.flush()
+
+    def spawn_plain(req_id, script, timeout):
+        td = tempfile.mkdtemp(prefix="ds1000_fork_")
+        out_path = os.path.join(td, "__out__.txt")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        try:
+            pid = os.fork()
+        except OSError:
+            shutil.rmtree(td, ignore_errors=True)
+            respond(req_id, f"\n<<<WORKER {req_id} CHILD_EXIT fork>>>")
+            return
+        if pid == 0:
+            run_child(script, timeout, out_path, td)
+        children[pid] = (req_id, out_path, td, time.time() + timeout + 15)
+
+    def run_fallback(req):
+        spawn_plain(req["id"], req["fallback"], req.get("timeout", 30))
+
+    def kill_session(skey):
+        s = sessions.pop(skey, None)
+        if s is None:
+            return
+        session_pids.pop(s["pid"], None)
+        for fd in (s["cmd_w"], s["res_r"]):
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        try:
+            os.killpg(s["pid"], signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+        shutil.rmtree(s["td"], ignore_errors=True)
+
+    def fail_session(skey):
+        """Session became unusable: serve queued/inflight via fallback."""
+        s = sessions.get(skey)
+        if s is None:
+            return
+        pending = list(s["queue"])
+        if s["inflight"] is not None:
+            pending.insert(0, s["inflight"])
+            s["inflight"] = None
+        s["queue"].clear()
+        kill_session(skey)
+        sessions[skey] = {"state": "bad"}
+        for req in pending:
+            run_fallback(req)
+
+    def spawn_session(skey, setup):
+        cmd_r, cmd_w = os.pipe()
+        res_r, res_w = os.pipe()
+        td = tempfile.mkdtemp(prefix="ds1000_sess_")
+        sys.stdout.flush()
+        sys.stderr.flush()
+        try:
+            pid = os.fork()
+        except OSError:
+            shutil.rmtree(td, ignore_errors=True)
+            for fd in (cmd_r, cmd_w, res_r, res_w):
+                os.close(fd)
+            sessions[skey] = {"state": "bad"}
+            return
+        if pid == 0:
+            os.close(cmd_w)
+            os.close(res_r)
+            run_session(setup, cmd_r, res_w, td)
+        os.close(cmd_r)
+        os.close(res_w)
+        sessions[skey] = {
+            "state": "starting", "pid": pid, "cmd_w": cmd_w, "res_r": res_r,
+            "td": td, "queue": [], "inflight": None, "buf": b"", "seq": 0,
+        }
+        session_pids[pid] = skey
+
+    def pump(skey):
+        s = sessions.get(skey)
+        if not s or s.get("state") != "ready" or s["inflight"] or not s["queue"]:
+            return
+        req = s["queue"].pop(0)
+        s["inflight"] = req
+        req["_deadline"] = time.time() + req.get("timeout", 30) + 15
+        s["seq"] += 1
+        out_path = os.path.join(s["td"], f"__out_{s['seq']}__.txt")
+        req["_out_path"] = out_path
+        msg = {"id": req["id"], "body": req["body"],
+               "timeout": req.get("timeout", 30), "out": out_path}
+        try:
+            os.write(s["cmd_w"], (json.dumps(msg) + "\n").encode())
+        except OSError:
+            fail_session(skey)
+
+    def on_session_msg(skey, msg):
+        s = sessions.get(skey)
+        if s is None or "pid" not in s:
+            return
+        if msg.get("ready"):
+            s["state"] = "ready"
+            pump(skey)
+        elif msg.get("setup_failed"):
+            fail_session(skey)
+        elif "id" in msg:
+            req = s["inflight"]
+            s["inflight"] = None
+            if req is not None and req["id"] != msg["id"]:
+                run_fallback(req)
+            elif req is not None:
+                if msg.get("forkfail"):
+                    respond(req["id"], f"\n<<<WORKER {req['id']} CHILD_EXIT fork>>>")
+                else:
+                    out = _read_out(req["_out_path"])
+                    try:
+                        os.unlink(req["_out_path"])
+                    except OSError:
+                        pass
+                    respond(req["id"], out + _suffix_for_status(msg["status"], req["id"]))
+            pump(skey)
+
+    def handle_request(req):
+        if "skey" not in req:
+            spawn_plain(req["id"], req["script"], req.get("timeout", 30))
+            return
+        skey = req["skey"]
+        s = sessions.get(skey)
+        if s is not None and s.get("state") == "bad":
+            run_fallback(req)
+            return
+        if s is None:
+            if len([v for v in sessions.values() if "pid" in v]) >= MAX_SESSIONS:
+                evictable = [k for k, v in sessions.items()
+                             if v.get("state") == "ready"
+                             and not v["inflight"] and not v["queue"]]
+                if evictable:
+                    kill_session(evictable[0])
+                else:
+                    run_fallback(req)
+                    return
+            spawn_session(skey, req["setup"])
+            s = sessions.get(skey)
+            if s is None or s.get("state") == "bad":
+                run_fallback(req)
+                return
+        s["queue"].append(req)
+        pump(skey)
+
+    def enforce_deadlines():
+        now = time.time()
+        for pid, (_rid, _o, _t, deadline) in list(children.items()):
+            if now > deadline:
+                # in-child alarm was defeated (or never fired): kill from here;
+                # reap() collects and responds with the signal suffix.
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+        for skey, s in list(sessions.items()):
+            req = s.get("inflight") if "pid" in s else None
+            if req is not None and now > req.get("_deadline", now + 1):
+                fail_session(skey)
+
+    def reap():
+        while True:
+            try:
+                pid, status = os.waitpid(-1, os.WNOHANG)
+            except ChildProcessError:
+                break
+            if pid == 0:
+                break
+            if pid in session_pids:
+                fail_session(session_pids[pid])
+                continue
+            if pid not in children:
+                continue
+            req_id, out_path, td, _deadline = children.pop(pid)
+            out = _read_out(out_path) + _suffix_for_status(status, req_id)
+            shutil.rmtree(td, ignore_errors=True)
+            respond(req_id, out)
+
+    sys.stdout.write(json.dumps({"ready": True}) + "\n")
+    sys.stdout.flush()
+
+    buf = b""
+    stdin_fd = sys.stdin.fileno()
+    eof = False
+
+    def busy():
+        return (children
+                or any(v.get("inflight") or v.get("queue")
+                       for v in sessions.values() if "pid" in v))
+
+    while not eof or busy():
+        timeout = 0.05 if busy() else None
+        fds = [v["res_r"] for v in sessions.values() if "pid" in v]
+        read_stdin = not eof and len(children) < MAX_CHILDREN
+        if read_stdin:
+            fds.append(stdin_fd)
+        ready, _, _ = select.select(fds, [], [], timeout)
+        for fd in ready:
+            if fd == stdin_fd:
+                chunk = os.read(stdin_fd, 1 << 20)
+                if not chunk:
+                    eof = True
+                buf += chunk
+                continue
+            for skey, s in list(sessions.items()):
+                if s.get("res_r") == fd:
+                    try:
+                        chunk = os.read(fd, 1 << 20)
+                    except OSError:
+                        chunk = b""
+                    if not chunk:
+                        fail_session(skey)
+                        break
+                    s["buf"] += chunk
+                    while b"\n" in s["buf"]:
+                        line, s["buf"] = s["buf"].split(b"\n", 1)
+                        if not line.strip():
+                            continue
+                        try:
+                            msg = json.loads(line)
+                        except ValueError:
+                            fail_session(skey)
+                            break
+                        on_session_msg(skey, msg)
+                    break
+        # Buffered lines wait while the child cap is hit; they imply a live
+        # child, so the outer loop cannot exit with work queued.
+        while b"\n" in buf and len(children) < MAX_CHILDREN:
+            line, buf = buf.split(b"\n", 1)
+            if not line.strip():
+                continue
+            try:
+                req = json.loads(line)
+            except ValueError:
+                sys.stderr.write("worker: dropping malformed request line\n")
+                continue
+            handle_request(req)
+        enforce_deadlines()
+        reap()
+
+    for skey in list(sessions):
+        kill_session(skey)
+    for pid in list(children):
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+    deadline_children = dict(children)
+    while deadline_children:
+        try:
+            pid, _ = os.waitpid(-1, 0)
+        except ChildProcessError:
+            break
+        deadline_children.pop(pid, None)
+
+
+if __name__ == "__main__":
+    main()

--- a/genlm/eval/domains/ds1000/_forkserver_worker.py
+++ b/genlm/eval/domains/ds1000/_forkserver_worker.py
@@ -1,21 +1,14 @@
 #!/usr/bin/env python
 """
-Warm fork-server for DS-1000 harness scripts: pre-imports the science
-libraries once, then forks an isolated child per request (own tempdir cwd,
-redirected output, alarm timeout). tensorflow is not pre-imported
-(fork-unsafe).
+Warm fork-server for DS-1000 harness scripts: pre-imports the science libs
+(tensorflow excluded, fork-unsafe), forks an isolated child per request.
+Session requests keep a per-task child alive past setup and fork checks from
+it, serialized per task; session failures run the request's fallback script.
 
-Sessioned requests additionally keep a per-task child alive that has already
-executed the task's setup (code_context + test-input generation); each check
-forks from it and runs only the solution statements. Session checks are
-serialized per task; on any session failure the request's fallback script
-runs through the plain path.
-
-Protocol (JSON lines on stdin -> stdout {"id", "out"}):
-  plain:    {"id", "script", "timeout"}
-  session:  {"id", "skey", "setup", "body", "fallback", "timeout"}
-{"ready": true} once after warmup. On timeout/crash, "out" ends with
-"<<<TIMEOUT>>>" or "<<<CHILD_EXIT n>>>".
+JSON lines, stdin -> stdout {"id", "out"}; {"ready": true} after warmup.
+plain: {"id", "script", "timeout"}; session: {"id", "skey", "setup", "body",
+"fallback", "timeout"}. Worker timeout/crash verdicts end with an id-stamped
+"<<<WORKER <id> ...>>>" line.
 """
 
 import json

--- a/genlm/eval/domains/ds1000/forkserver.py
+++ b/genlm/eval/domains/ds1000/forkserver.py
@@ -1,0 +1,201 @@
+"""Warm fork-server execution backend for the DS-1000 potential.
+
+One worker per (python_executable, extra_env, event loop) pre-imports the
+science libraries and forks an isolated child per harness script, cutting
+per-check cost from seconds to milliseconds. Any backend failure raises
+ForkserverUnavailable; callers fall back to the plain subprocess path.
+"""
+
+import asyncio
+import atexit
+import json
+import os
+import signal
+import tempfile
+
+_WORKER_PATH = os.path.join(os.path.dirname(__file__), "_forkserver_worker.py")
+_STREAM_LIMIT = 32 * 1024 * 1024
+_MAX_START_ATTEMPTS = 3
+
+
+class ForkserverUnavailable(RuntimeError):
+    """The fork-server cannot serve requests; use the subprocess fallback."""
+
+
+class ForkserverExecutor:
+    def __init__(self, python_executable: str, extra_env=None):
+        self.python_executable = python_executable
+        self.extra_env = dict(extra_env or {})
+        self.proc = None
+        self._futures = {}
+        self._next_id = 0
+        self._wlock = asyncio.Lock()
+        self._start_lock = asyncio.Lock()
+        self._start_attempts = 0
+        self.failed = False
+        self.loop = None
+        self.stderr_log = None
+
+    async def _ensure_started(self):
+        async with self._start_lock:
+            if self.failed:
+                raise ForkserverUnavailable("fork-server permanently failed")
+            if self.proc is not None and self.proc.returncode is None:
+                return
+            if self._start_attempts >= _MAX_START_ATTEMPTS:
+                self.failed = True
+                raise ForkserverUnavailable("fork-server start attempts exhausted")
+            self._start_attempts += 1
+            try:
+                env = dict(os.environ)
+                env.update(self.extra_env)
+                log = tempfile.NamedTemporaryFile(
+                    mode="w", prefix="ds1000_worker_", suffix=".log", delete=False
+                )
+                self.stderr_log = log.name
+                self.proc = await asyncio.create_subprocess_exec(
+                    self.python_executable,
+                    "-u",
+                    _WORKER_PATH,
+                    stdin=asyncio.subprocess.PIPE,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=log,
+                    env=env,
+                    limit=_STREAM_LIMIT,
+                )
+                ready = json.loads(
+                    await asyncio.wait_for(self.proc.stdout.readline(), timeout=300)
+                )
+                if not ready.get("ready"):
+                    raise RuntimeError(f"unexpected worker handshake: {ready!r}")
+            except Exception as exc:
+                self.kill()
+                raise ForkserverUnavailable(f"fork-server start failed: {exc}") from exc
+            # Fresh futures per worker generation: a late cleanup from a dead
+            # generation's reader must not clobber the new generation.
+            self._futures = {}
+            asyncio.get_running_loop().create_task(
+                self._reader(self.proc, self._futures)
+            )
+
+    async def _reader(self, proc, futures):
+        try:
+            while True:
+                line = await proc.stdout.readline()
+                if not line:
+                    break
+                msg = json.loads(line)
+                fut = futures.pop(msg["id"], None)
+                if fut is not None and not fut.done():
+                    fut.set_result(msg["out"])
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            for fut in futures.values():
+                if not fut.done():
+                    fut.set_exception(ForkserverUnavailable("worker stream ended"))
+            futures.clear()
+
+    async def run(self, script: str, timeout: float):
+        """
+        Run a harness script in a forked child. Returns combined stdout+stderr,
+        or None on timeout/child crash. Raises ForkserverUnavailable on backend
+        failure (caller falls back to a plain subprocess).
+        """
+        return await self._request(
+            {"script": script, "timeout": timeout},
+            timeout,
+            wait_extra=30,
+            congestion_raises=True,
+        )
+
+    async def run_session(self, skey, setup, body, fallback, timeout):
+        """
+        Run `body` in a warm per-task session (setup executed once per skey);
+        the worker runs `fallback` through the plain path if the session is
+        unusable. Same return contract as run().
+        """
+        # Session requests may wait behind one-off setup (<=120s) and the
+        # per-task serialized checks, so budget slack from the timeout.
+        return await self._request(
+            {
+                "skey": skey,
+                "setup": setup,
+                "body": body,
+                "fallback": fallback,
+                "timeout": timeout,
+            },
+            timeout,
+            wait_extra=120 + 10 * timeout,
+        )
+
+    async def _request(
+        self,
+        payload_fields: dict,
+        timeout: float,
+        wait_extra: float = 30,
+        congestion_raises: bool = False,
+    ):
+        await self._ensure_started()
+        self._next_id += 1
+        rid = self._next_id
+        fut = asyncio.get_running_loop().create_future()
+        self._futures[rid] = fut
+        payload = json.dumps({"id": rid, **payload_fields}) + "\n"
+        try:
+            async with self._wlock:
+                self.proc.stdin.write(payload.encode())
+                await self.proc.stdin.drain()
+        except Exception as exc:
+            self._futures.pop(rid, None)
+            raise ForkserverUnavailable(f"fork-server write failed: {exc}") from exc
+        try:
+            out = await asyncio.wait_for(fut, timeout=timeout + wait_extra)
+        except asyncio.TimeoutError:
+            self._futures.pop(rid, None)
+            # No worker verdict at all: backend congestion, not a script
+            # timeout (the worker stamps those). Strict callers re-run via
+            # the subprocess fallback rather than misreading it as -inf.
+            if congestion_raises:
+                raise ForkserverUnavailable("fork-server response overdue")
+            return None
+        # The worker reports timeout/crash via an id-stamped final line that
+        # solution prints cannot spoof.
+        last = out.rstrip().rsplit("\n", 1)[-1]
+        if last.startswith(f"<<<WORKER {rid} "):
+            return None
+        return out
+
+    def kill(self):
+        proc, self.proc = self.proc, None
+        if proc is not None and proc.returncode is None:
+            # os.kill is independent of the (possibly closed) event loop.
+            try:
+                os.kill(proc.pid, signal.SIGKILL)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+_executors = {}
+
+
+def shared_executor(python_executable: str, extra_env=None) -> ForkserverExecutor:
+    """Executor shared per (python, extra_env, running event loop)."""
+    loop = asyncio.get_running_loop()
+    for k, ex in list(_executors.items()):
+        if ex.loop is not None and ex.loop.is_closed():
+            ex.kill()
+            del _executors[k]
+    key = (id(loop), python_executable, frozenset((extra_env or {}).items()))
+    executor = _executors.get(key)
+    if executor is None:
+        executor = ForkserverExecutor(python_executable, extra_env)
+        executor.loop = loop
+        _executors[key] = executor
+    return executor
+
+
+@atexit.register
+def _cleanup():
+    for executor in _executors.values():
+        executor.kill()

--- a/genlm/eval/domains/ds1000/forkserver.py
+++ b/genlm/eval/domains/ds1000/forkserver.py
@@ -163,10 +163,21 @@ class ForkserverExecutor:
 
     def kill(self):
         proc, self.proc = self.proc, None
-        if proc is not None and proc.returncode is None:
+        if proc is None:
+            return
+        if proc.returncode is None:
             # os.kill is independent of the (possibly closed) event loop.
             try:
                 os.kill(proc.pid, signal.SIGKILL)
+            except Exception:  # noqa: BLE001
+                pass
+        # Close the asyncio transport now: close() sets its closed flag before
+        # touching the (possibly dead) loop, so the later shutdown-GC __del__
+        # is a no-op -- avoids benign "Event loop is closed" tracebacks.
+        transport = getattr(proc, "_transport", None)
+        if transport is not None:
+            try:
+                transport.close()
             except Exception:  # noqa: BLE001
                 pass
 

--- a/genlm/eval/domains/ds1000/forkserver.py
+++ b/genlm/eval/domains/ds1000/forkserver.py
@@ -1,9 +1,7 @@
-"""Warm fork-server execution backend for the DS-1000 potential.
-
-One worker per (python_executable, extra_env, event loop) pre-imports the
-science libraries and forks an isolated child per harness script, cutting
-per-check cost from seconds to milliseconds. Any backend failure raises
-ForkserverUnavailable; callers fall back to the plain subprocess path.
+"""Warm fork-server execution backend for the DS-1000 potential: one worker
+per (python_executable, extra_env, event loop), forking a child per check.
+Backend failures raise ForkserverUnavailable; callers fall back to plain
+subprocesses.
 """
 
 import asyncio
@@ -111,12 +109,10 @@ class ForkserverExecutor:
 
     async def run_session(self, skey, setup, body, fallback, timeout):
         """
-        Run `body` in a warm per-task session (setup executed once per skey);
-        the worker runs `fallback` through the plain path if the session is
-        unusable. Same return contract as run().
+        Run `body` in a warm per-task session (setup once per skey; the worker
+        falls back to `fallback` if the session is unusable). Contract of run().
         """
-        # Session requests may wait behind one-off setup (<=120s) and the
-        # per-task serialized checks, so budget slack from the timeout.
+        # Slack for one-off setup (<=120s) plus per-task serialized checks.
         return await self._request(
             {
                 "skey": skey,
@@ -153,9 +149,8 @@ class ForkserverExecutor:
             out = await asyncio.wait_for(fut, timeout=timeout + wait_extra)
         except asyncio.TimeoutError:
             self._futures.pop(rid, None)
-            # No worker verdict at all: backend congestion, not a script
-            # timeout (the worker stamps those). Strict callers re-run via
-            # the subprocess fallback rather than misreading it as -inf.
+            # No worker verdict = backend congestion, not a script timeout
+            # (the worker stamps those); strict callers re-run via fallback.
             if congestion_raises:
                 raise ForkserverUnavailable("fork-server response overdue")
             return None

--- a/genlm/eval/domains/ds1000/forkserver.py
+++ b/genlm/eval/domains/ds1000/forkserver.py
@@ -1,7 +1,5 @@
-"""Warm fork-server execution backend for the DS-1000 potential: one worker
-per (python_executable, extra_env, event loop), forking a child per check.
-Backend failures raise ForkserverUnavailable; callers fall back to plain
-subprocesses.
+"""Warm fork-server execution backend for the DS-1000 potential. Backend
+failures raise ForkserverUnavailable; callers fall back to subprocesses.
 """
 
 import asyncio

--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -1,20 +1,88 @@
 from typing import Callable, Dict, List, Optional
 import asyncio
+import ast
+import codeop
 from collections import OrderedDict
+import re
 import tempfile
 import subprocess
 import sys
 import textwrap
 import os
+import uuid
 
 from genlm.control import Potential
+from genlm.eval.domains.ds1000.forkserver import ForkserverUnavailable, shared_executor
 from genlm.eval.domains.ds1000.utils import _postprocess_code, _sandbox_env
+
+# Once one of these appears in the raw generation, _postprocess_code truncates
+# there and no continuation can change the solution anymore.
+_TERMINAL_MARKERS = ("</code>", "\nEND SOLUTION")
+
+
+def _prefix_syntax_status(code: str) -> str:
+    """
+    Classify a solution prefix: "complete" (parses), "incomplete" (a
+    continuation can still fix it), or "broken" (no continuation can).
+    """
+    # codeop misclassifies a trailing line-continuation backslash as broken.
+    if code.endswith("\\\n"):
+        return "incomplete"
+    try:
+        ast.parse(code)
+        return "complete"
+    except SyntaxError:
+        pass
+    try:
+        if codeop.compile_command(code, "<prefix>", "exec") is None:
+            return "incomplete"
+        # codeop compiled what ast.parse rejected; be conservative and defer.
+        return "incomplete"
+    except (SyntaxError, ValueError, OverflowError):
+        return "broken"
+
+
+def _test_case_count(code_context: str) -> int:
+    """Number of test cases iterated by test_execution in the code context."""
+    m = re.search(
+        r"def test_execution.*?for\s+i\s+in\s+range\((\d+)\)", code_context, re.S
+    )
+    return int(m.group(1)) if m else 1
+
+
+def _exec_context_head(code_context: str):
+    """
+    Return (head, is_block_insert): the exec_context source before the
+    `[insert]` line (None if not found), and whether `[insert]` stands alone
+    on its line. Some problems insert the solution as an indented function
+    body that only parses together with the head; inline inserts (e.g.
+    `[insert].numpy()`) cannot be partially executed at all.
+    """
+    m = re.search(r"exec_context\s*=\s*r?(\"\"\"|''')(.*?)\1", code_context, re.S)
+    if not m:
+        return None, False
+    exec_context = m.group(2)
+    lines = exec_context.split("\n")
+    for i, line in enumerate(lines):
+        if "[insert]" in line:
+            head = "\n".join(lines[:i])
+            if head:
+                head += "\n"
+            return head, line == "[insert]"
+    return None, False
 
 
 class DS1000RuntimeNoErrorPotential(Potential):
     """
-    DS-1000 expensive potential: execute the harness on a complete prefix.
-    Return 0.0 if no error, -inf otherwise.
+    DS-1000 expensive potential: execute the harness on a code prefix or a
+    complete solution. Return 0.0 if no error, -inf otherwise.
+
+    prefix() asks "can this prefix still extend to a valid solution": it
+    executes only `exec_context` up to `[insert]` plus the partial solution,
+    skipping the answer checks (result extraction, exec_test, context tail)
+    that a partial solution legitimately cannot satisfy yet; syntactically
+    incomplete prefixes are deferred (0.0). complete() runs the full
+    `test_execution` harness; any non-assertion error is -inf.
     """
 
     def __init__(
@@ -25,6 +93,8 @@ class DS1000RuntimeNoErrorPotential(Potential):
         python_executable: Optional[str] = None,
         extra_env: Optional[Dict[str, str]] = None,
         f: Optional[Callable[[List[bytes]], List[bytes]]] = None,
+        strict_prefix: bool = False,
+        use_forkserver: bool = False,
     ):
         vocabulary = vocabulary or [bytes([i]) for i in range(256)]
         super().__init__(vocabulary=vocabulary)
@@ -34,6 +104,24 @@ class DS1000RuntimeNoErrorPotential(Potential):
         self.extra_env = dict(extra_env or {})
         self.last_was_syntax_error = False
         self.f = f
+        # strict_prefix=True scores prefixes with the full harness (answer
+        # checks included) instead of the head-only check.
+        self.strict_prefix = bool(strict_prefix)
+        # use_forkserver=True runs harness scripts through a warm fork-server
+        # (one shared worker per python executable) instead of a fresh
+        # subprocess per check; on any backend failure it falls back to the
+        # subprocess path. Note: env vars read at interpreter startup (e.g.
+        # PYTHONHASHSEED) only take effect at worker start.
+        self.use_forkserver = bool(use_forkserver)
+        self._n_test_cases = _test_case_count(code_context)
+        self._ec_head, self._ec_block_insert = _exec_context_head(code_context)
+        self._session_key = "ds1000-" + uuid.uuid5(
+            uuid.NAMESPACE_OID, code_context
+        ).hex
+        # Prefixes whose check timed out: extensions re-run the same leading
+        # statements, so defer them without paying the timeout again.
+        self._hung_prefixes = []
+        self._hung_prefixes_maxsize = 16
         # SMC frequently clones particles into identical or repeated prefixes.
         # Cache exact postprocessed code strings to avoid launching duplicate
         # DS1000 subprocess checks. The cache is per potential instance, whose
@@ -56,6 +144,8 @@ class DS1000RuntimeNoErrorPotential(Potential):
             python_executable=self.python_executable,
             extra_env=self.extra_env,
             f=f,
+            strict_prefix=self.strict_prefix,
+            use_forkserver=self.use_forkserver,
         )
 
     def _bytes_to_str(self, toks):
@@ -86,12 +176,40 @@ class DS1000RuntimeNoErrorPotential(Potential):
     async def prefix(self, context: List[bytes]) -> float:
         if self.f is not None:
             context = self.f(context)
-        code = self._bytes_to_str(context)
+        raw = self._bytes_to_str(context)
         # Newline guardrail when using the default sampler.
-        if not code.endswith("\n"):
+        if not raw.endswith("\n"):
             return 0.0
-        code = _postprocess_code(code)
-        out = await self._score_no_error(code)
+        code = _postprocess_code(raw)
+        if self.strict_prefix:
+            out = await self._score_no_error(code, mode="complete")
+            return out
+        terminal = any(marker in raw for marker in _TERMINAL_MARKERS)
+        if not code.strip():
+            return float("-inf") if terminal else 0.0
+        if terminal:
+            # The solution can no longer change: apply the strict check.
+            out = await self._score_no_error(code, mode="complete")
+            return out
+        if self._ec_head is not None and not self._ec_block_insert:
+            # Inline insertion (e.g. `[insert].numpy()`): defer to complete().
+            return 0.0
+        for hung in self._hung_prefixes:
+            if code.startswith(hung):
+                return 0.0
+        # Syntax is only meaningful for head + solution combined (the solution
+        # may be an indented function body).
+        combined = (self._ec_head or "") + code
+        status = _prefix_syntax_status(combined)
+        if status == "incomplete":
+            self.last_was_syntax_error = False
+            return 0.0
+        if status == "broken" and "skip_plt_cmds" not in self.code_context:
+            # Unfixable. Matplotlib harnesses go to the subprocess instead:
+            # their solution-line filtering can repair the parse.
+            self.last_was_syntax_error = True
+            return float("-inf")
+        out = await self._score_no_error(code, mode="prefix")
         return out
 
     async def complete(self, context: List[bytes]):
@@ -105,37 +223,19 @@ class DS1000RuntimeNoErrorPotential(Potential):
         # The LM often emits EOS / "</code>" as the first token.
         if not code:
             return float("-inf")
-        out = await self._score_no_error(code)
+        out = await self._score_no_error(code, mode="complete")
         return out
 
-    async def _score_no_error(self, complete_code: str) -> float:
-        """
-        Run the harness script in a subprocess and check for runtime errors.
-        Returns 0.0 if no error (incl. AssertionError), -inf otherwise.
-
-        complete_code: str - the complete code to run
-        Returns:
-            float - 0.0 if no error, -inf otherwise.
-        """
-        cached = self._score_cache.get(complete_code)
-        if cached is not None:
-            self._score_cache.move_to_end(complete_code)
-            self.cache_hits += 1
-            value, syntax_error = cached
-            self.last_was_syntax_error = syntax_error
-            return value
-        self.cache_misses += 1
-
-        OK, BAD, SYNTAX = "<<<OK>>>", "<<<BAD>>>", "<<<SYNTAX>>>"
-
-        script = textwrap.dedent(
+    def _complete_script(self, complete_code: str, ok: str, bad: str, syntax: str) -> str:
+        """Harness script for complete solutions: run test_execution as-is."""
+        return textwrap.dedent(
             f"""
             import sys, warnings, os, ast
             warnings.filterwarnings("ignore")
             os.environ.setdefault("PYTHONWARNINGS", "ignore")
             os.environ.setdefault("MPLBACKEND", "Agg")
 
-            OK, BAD, SYNTAX = "<<<OK>>>", "<<<BAD>>>", "<<<SYNTAX>>>"
+            OK, BAD, SYNTAX = {ok!r}, {bad!r}, {syntax!r}
             code_context = {self.code_context!r}
             answer = {complete_code!r}
             try:
@@ -144,8 +244,17 @@ class DS1000RuntimeNoErrorPotential(Potential):
                 te = g.get("test_execution")
                 if not callable(te):
                     print(BAD); raise SystemExit(0)
-                try: # ast.parse to check if the answer is valid code
-                    ast.parse(answer, filename="<answer>", mode="exec")
+                # Syntax-check the answer as the harness runs it: inserted
+                # into exec_context, matplotlib line filtering applied.
+                to_check = answer
+                skip = g.get("skip_plt_cmds")
+                if callable(skip):
+                    to_check = "\\n".join(filter(skip, to_check.split("\\n")))
+                exec_context = g.get("exec_context")
+                if isinstance(exec_context, str) and "[insert]" in exec_context:
+                    to_check = exec_context.replace("[insert]", to_check)
+                try:
+                    ast.parse(to_check, filename="<answer>", mode="exec")
                 except SyntaxError:
                     print(SYNTAX); raise SystemExit(0)
                 try:
@@ -167,6 +276,205 @@ class DS1000RuntimeNoErrorPotential(Potential):
             """
         ).strip()
 
+    def _prefix_script(self, prefix_code: str, ok: str, bad: str, syntax: str) -> str:
+        """
+        Script for solution prefixes: per test case, execute exec_context
+        head + partial solution parsed as ONE program (the solution may be an
+        indented function body), skipping everything after the insertion
+        point. A trailing compound statement is dropped since the generation
+        may still extend its suite.
+        """
+        return textwrap.dedent(
+            f"""
+            import sys, warnings, os, ast
+            warnings.filterwarnings("ignore")
+            os.environ.setdefault("PYTHONWARNINGS", "ignore")
+            os.environ.setdefault("MPLBACKEND", "Agg")
+
+            OK, BAD, SYNTAX = {ok!r}, {bad!r}, {syntax!r}
+            code_context = {self.code_context!r}
+            answer = {prefix_code!r}
+            head = {self._ec_head!r}
+            n_cases = {self._n_test_cases}
+            try:
+                g = {{}}
+                exec(code_context, g, g)
+                gtc = g.get("generate_test_case")
+                if head is None or not callable(gtc):
+                    # Unknown harness structure: never kill a prefix we cannot
+                    # faithfully execute.
+                    print(OK); raise SystemExit(0)
+                solution = answer
+                # Matplotlib harnesses drop plt.show()/savefig/... lines from
+                # the solution before executing it; mirror that here.
+                skip = g.get("skip_plt_cmds")
+                if callable(skip):
+                    solution = "\\n".join(filter(skip, solution.split("\\n")))
+                if solution.endswith("\\\\\\n"):
+                    # Trailing line-continuation: defer to a later boundary.
+                    print(OK); raise SystemExit(0)
+                try:
+                    tree = ast.parse(head + solution, filename="<prefix>", mode="exec")
+                except SyntaxError:
+                    print(SYNTAX); raise SystemExit(0)
+                # A trailing compound statement (for/if/def/... -- anything with
+                # a body) may still be extended by the generation, so executing
+                # it now could raise errors the full solution would not.
+                if tree.body and hasattr(tree.body[-1], "body"):
+                    tree.body = tree.body[:-1]
+                # Statements starting within the head (which alone may not
+                # parse, e.g. a dangling def the solution completes) are
+                # harness-side; the rest belong to the solution.
+                head_lines = head.count("\\n")
+                n_head = sum(1 for st in tree.body if st.lineno <= head_lines)
+                head_prog = compile(
+                    ast.Module(body=tree.body[:n_head], type_ignores=[]),
+                    "<prefix>",
+                    "exec",
+                )
+                sol_prog = compile(
+                    ast.Module(body=tree.body[n_head:], type_ignores=[]),
+                    "<prefix>",
+                    "exec",
+                )
+                for i in range(n_cases):
+                    # Failures while building the test environment (some
+                    # harnesses set up files etc. inside test_execution) are
+                    # not the solution's fault: defer.
+                    try:
+                        test_input, expected_result = gtc(i + 1)
+                        test_env = {{"test_input": test_input}}
+                        exec(head_prog, test_env)
+                    except Exception:
+                        print(OK); raise SystemExit(0)
+                    exec(sol_prog, test_env)
+                print(OK)
+            except AssertionError:
+                print(OK)
+            except SyntaxError:
+                print(SYNTAX)
+            except Exception:
+                print(BAD)
+            """
+        ).strip()
+
+    async def _run_prefix_script(self, prefix_code, fallback_script, ok, bad, syntax):
+        """
+        Run a prefix check, preferring a warm per-task session (task setup
+        executed once, each check forks from it). Any session/backend failure
+        falls back to the stateless paths.
+        """
+        if (
+            self.use_forkserver
+            and self._ec_head is not None
+            and self._ec_block_insert
+            and os.environ.get("DS1000_FORKSERVER_SESSIONS", "1") != "0"
+        ):
+            try:
+                executor = shared_executor(self.python_executable, self.extra_env)
+                return await executor.run_session(
+                    skey=self._session_key,
+                    setup=self._session_setup_script(),
+                    body=self._session_body_script(prefix_code, ok, bad, syntax),
+                    fallback=fallback_script,
+                    timeout=self.timeout_seconds,
+                )
+            except ForkserverUnavailable:
+                # Keep the chain interceptable for subclasses overriding
+                # _run_script (it falls back to the subprocess itself).
+                return await self._run_script(fallback_script)
+        return await self._run_script(fallback_script)
+
+    def _session_setup_script(self) -> str:
+        """Once-per-task session setup: context exec + test-input generation."""
+        return textwrap.dedent(
+            f"""
+            import warnings, os
+            warnings.filterwarnings("ignore")
+            os.environ.setdefault("PYTHONWARNINGS", "ignore")
+            os.environ.setdefault("MPLBACKEND", "Agg")
+
+            code_context = {self.code_context!r}
+            head = {self._ec_head!r}
+            n_cases = {self._n_test_cases}
+            g = {{}}
+            exec(code_context, g, g)
+            gtc = g.get("generate_test_case")
+            if not callable(gtc):
+                raise RuntimeError("unknown harness structure")
+            skip = g.get("skip_plt_cmds")
+            test_inputs = [gtc(i + 1)[0] for i in range(n_cases)]
+            head_lines = head.count("\\n")
+            # Warm the head's imports so per-check forks hit sys.modules.
+            for _line in head.split("\\n"):
+                if _line.startswith(("import ", "from ")):
+                    try:
+                        exec(_line, {{}}, {{}})
+                    except Exception:
+                        pass
+            """
+        ).strip()
+
+    def _session_body_script(self, prefix_code: str, ok, bad, syntax) -> str:
+        """Per-check body run in a fork of the session (uses its namespace)."""
+        return textwrap.dedent(
+            f"""
+            import ast
+            OK, BAD, SYNTAX = {ok!r}, {bad!r}, {syntax!r}
+            answer = {prefix_code!r}
+            try:
+                solution = answer
+                if callable(skip):
+                    solution = "\\n".join(filter(skip, solution.split("\\n")))
+                if solution.endswith("\\\\\\n"):
+                    print(OK); raise SystemExit(0)
+                try:
+                    tree = ast.parse(head + solution, filename="<prefix>", mode="exec")
+                except SyntaxError:
+                    print(SYNTAX); raise SystemExit(0)
+                if tree.body and hasattr(tree.body[-1], "body"):
+                    tree.body = tree.body[:-1]
+                n_head = sum(1 for st in tree.body if st.lineno <= head_lines)
+                head_prog = compile(
+                    ast.Module(body=tree.body[:n_head], type_ignores=[]),
+                    "<prefix>", "exec",
+                )
+                sol_prog = compile(
+                    ast.Module(body=tree.body[n_head:], type_ignores=[]),
+                    "<prefix>", "exec",
+                )
+                for ti in test_inputs:
+                    test_env = {{"test_input": ti}}
+                    try:
+                        exec(head_prog, test_env)
+                    except Exception:
+                        print(OK); raise SystemExit(0)
+                    exec(sol_prog, test_env)
+                print(OK)
+            except AssertionError:
+                print(OK)
+            except SyntaxError:
+                print(SYNTAX)
+            except Exception:
+                print(BAD)
+            """
+        ).strip()
+
+    async def _run_script(self, script: str):
+        """
+        Run a harness script; return its combined stdout+stderr, or None on
+        timeout. Uses the fork-server when enabled, falling back to a fresh
+        sandboxed subprocess on any backend failure.
+        """
+        if self.use_forkserver:
+            try:
+                executor = shared_executor(self.python_executable, self.extra_env)
+                return await executor.run(script, self.timeout_seconds)
+            except ForkserverUnavailable:
+                pass
+        return await self._run_script_subprocess(script)
+
+    async def _run_script_subprocess(self, script: str):
         try:
             with tempfile.TemporaryDirectory(prefix="ds1000_rt_") as td:
                 path = os.path.join(td, "rt_harness.py")
@@ -181,15 +489,19 @@ class DS1000RuntimeNoErrorPotential(Potential):
                     },
                 )
 
-                proc = await asyncio.create_subprocess_exec(
-                    self.python_executable,
-                    "-B",
-                    path,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    env=env,
-                    cwd=td,
-                )
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        self.python_executable,
+                        "-B",
+                        path,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        env=env,
+                        cwd=td,
+                    )
+                except OSError:
+                    # fork/pid exhaustion under load: transient, defer
+                    return None
                 try:
                     stdout_b, stderr_b = await asyncio.wait_for(
                         proc.communicate(), timeout=self.timeout_seconds
@@ -197,22 +509,69 @@ class DS1000RuntimeNoErrorPotential(Potential):
                 except asyncio.TimeoutError:
                     proc.kill()
                     await proc.communicate()
-                    return float("-inf")
+                    return None
         except subprocess.TimeoutExpired:
-            return float("-inf")
+            return None
 
-        out = stdout_b.decode("utf-8", errors="replace") + stderr_b.decode(
+        return stdout_b.decode("utf-8", errors="replace") + stderr_b.decode(
             "utf-8", errors="replace"
         )
+
+    async def _score_no_error(self, complete_code: str, mode: str = "complete") -> float:
+        """
+        Run the harness script in a subprocess: 0.0 if no error (incl.
+        AssertionError), -inf otherwise. mode="complete" runs the full
+        test_execution harness; "prefix" only the context head + solution.
+        """
+        cache_key = (mode, complete_code)
+        cached = self._score_cache.get(cache_key)
+        if cached is not None:
+            self._score_cache.move_to_end(cache_key)
+            self.cache_hits += 1
+            value, syntax_error = cached
+            self.last_was_syntax_error = syntax_error
+            return value
+        self.cache_misses += 1
+
+        # Per-invocation nonce so solution code cannot spoof the verdict by
+        # printing a guessable marker string.
+        nonce = uuid.uuid4().hex[:12]
+        OK = f"<<<OK:{nonce}>>>"
+        BAD = f"<<<BAD:{nonce}>>>"
+        SYNTAX = f"<<<SYNTAX:{nonce}>>>"
+
+        if mode == "prefix":
+            script = self._prefix_script(complete_code, OK, BAD, SYNTAX)
+            out = await self._run_prefix_script(complete_code, script, OK, BAD, SYNTAX)
+        else:
+            script = self._complete_script(complete_code, OK, BAD, SYNTAX)
+            out = await self._run_script(script)
+        if out is None:
+            # Timeout: a slow-but-valid prefix may still have a correct
+            # continuation, so defer; only complete() treats it as fatal.
+            self.last_was_syntax_error = False
+            if mode == "prefix":
+                self._hung_prefixes.append(complete_code)
+                if len(self._hung_prefixes) > self._hung_prefixes_maxsize:
+                    self._hung_prefixes.pop(0)
+                return 0.0
+            return float("-inf")
+
         ok = any(line.strip() == OK for line in out.splitlines())
         bad = any(line.strip() == BAD for line in out.splitlines())
         syntax = any(line.strip() == SYNTAX for line in out.splitlines())
 
+        if mode == "prefix" and not (ok or bad or syntax):
+            # No verdict marker (hard crash / garbled output): transient for a
+            # prefix, like a timeout -- defer, uncached.
+            self.last_was_syntax_error = False
+            return 0.0
+
         self.last_was_syntax_error = bool(syntax)
         bad = bad or syntax
         value = 0.0 if ok and not bad else float("-inf")
-        self._score_cache[complete_code] = (value, self.last_was_syntax_error)
-        self._score_cache.move_to_end(complete_code)
+        self._score_cache[cache_key] = (value, self.last_was_syntax_error)
+        self._score_cache.move_to_end(cache_key)
         if len(self._score_cache) > self._score_cache_maxsize:
             self._score_cache.popitem(last=False)
         return value

--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -19,6 +19,70 @@ from genlm.eval.domains.ds1000.utils import _postprocess_code, _sandbox_env
 # there and no continuation can change the solution anymore.
 _TERMINAL_MARKERS = ("</code>", "\nEND SOLUTION")
 
+# Bound concurrent subprocess spawns per event loop: asyncio's default child
+# watcher starts one OS thread per subprocess, so an unbounded fallback storm
+# (e.g. fork-server down + high caller concurrency) exhausts the thread limit.
+_subprocess_sems = {}
+
+
+def _subprocess_sem():
+    loop = asyncio.get_running_loop()
+    sem = _subprocess_sems.get(id(loop))
+    if sem is None:
+        n = int(os.environ.get("DS1000_SUBPROCESS_CONCURRENCY", "8"))
+        sem = asyncio.Semaphore(n)
+        _subprocess_sems[id(loop)] = sem
+    return sem
+
+# Single source of truth for prefix judging, embedded verbatim into every
+# harness script (stateless and session) so the paths cannot drift. Defines
+# `_judge_prefix`, returning one of the OK/BAD/SYNTAX markers. chr(10)/chr(92)
+# stand in for newline/backslash to keep this free of escape sequences when
+# emitted into a generated script.
+_PREFIX_JUDGE_SRC = '''
+def _judge_prefix(answer, head, skip, test_inputs, OK, BAD, SYNTAX):
+    import ast
+    _nl = chr(10)
+    try:
+        solution = answer
+        # Matplotlib harnesses drop plt.show()/savefig/... before executing.
+        if callable(skip):
+            solution = _nl.join(filter(skip, solution.split(_nl)))
+        # Trailing line-continuation: a later boundary completes it -> defer.
+        if solution.rstrip().endswith(chr(92)):
+            return OK
+        try:
+            tree = ast.parse(head + solution, filename="<prefix>", mode="exec")
+        except SyntaxError:
+            return SYNTAX
+        # A trailing compound statement may still be extended: do not run it.
+        if tree.body and hasattr(tree.body[-1], "body"):
+            tree.body = tree.body[:-1]
+        # Head statements (head alone may not parse, e.g. a dangling def) are
+        # harness-side; the rest is the solution.
+        head_lines = head.count(_nl)
+        n_head = sum(1 for st in tree.body if st.lineno <= head_lines)
+        head_prog = compile(
+            ast.Module(body=tree.body[:n_head], type_ignores=[]), "<prefix>", "exec")
+        sol_prog = compile(
+            ast.Module(body=tree.body[n_head:], type_ignores=[]), "<prefix>", "exec")
+        for ti in test_inputs:
+            test_env = {"test_input": ti}
+            try:
+                exec(head_prog, test_env)
+            except Exception:
+                # Test-environment setup failure is not the solution's fault.
+                return OK
+            exec(sol_prog, test_env)
+        return OK
+    except AssertionError:
+        return OK
+    except SyntaxError:
+        return SYNTAX
+    except Exception:
+        return BAD
+'''
+
 
 def _prefix_syntax_status(code: str) -> str:
     """
@@ -90,7 +154,7 @@ class DS1000RuntimeNoErrorPotential(Potential):
         extra_env: Optional[Dict[str, str]] = None,
         f: Optional[Callable[[List[bytes]], List[bytes]]] = None,
         strict_prefix: bool = False,
-        use_forkserver: bool = False,
+        use_forkserver: bool = True,
     ):
         vocabulary = vocabulary or [bytes([i]) for i in range(256)]
         super().__init__(vocabulary=vocabulary)
@@ -103,10 +167,16 @@ class DS1000RuntimeNoErrorPotential(Potential):
         # strict_prefix=True scores prefixes with the full harness (answer
         # checks included) instead of the head-only check.
         self.strict_prefix = bool(strict_prefix)
-        # use_forkserver=True: warm fork-server instead of a subprocess per
-        # check, with subprocess fallback on backend failure. Startup-time env
-        # vars (e.g. PYTHONHASHSEED) only apply at worker start.
-        self.use_forkserver = bool(use_forkserver)
+        # Warm fork-server (default), same verdicts as the subprocess path but
+        # faster, with subprocess fallback. DS1000_FORKSERVER=0 is the ops
+        # kill-switch; startup env vars (e.g. PYTHONHASHSEED) apply at worker start.
+        if os.environ.get("DS1000_FORKSERVER") == "0":
+            use_forkserver = False
+        # TensorFlow is unsafe to import in a forked child (it is the one lib
+        # the worker does not pre-import); such checks fork-then-import TF and
+        # mis-score. Force the subprocess path (fresh interpreter) for them.
+        self._fork_unsafe = "import tensorflow" in code_context
+        self.use_forkserver = bool(use_forkserver) and not self._fork_unsafe
         self._n_test_cases = _test_case_count(code_context)
         self._ec_head, self._ec_block_insert = _exec_context_head(code_context)
         self._session_key = "ds1000-" + uuid.uuid5(
@@ -266,15 +336,14 @@ class DS1000RuntimeNoErrorPotential(Potential):
 
     def _prefix_script(self, prefix_code: str, ok: str, bad: str, syntax: str) -> str:
         """
-        Script for solution prefixes: per test case, execute exec_context
-        head + partial solution parsed as ONE program (the solution may be an
-        indented function body), skipping everything after the insertion
-        point. A trailing compound statement is dropped since the generation
-        may still extend its suite.
+        Stateless prefix script: exec the code_context to build the test
+        inputs, then delegate to the shared `_judge_prefix`.
         """
-        return textwrap.dedent(
-            f"""
-            import sys, warnings, os, ast
+        return (
+            _PREFIX_JUDGE_SRC
+            + textwrap.dedent(
+                f"""
+            import warnings, os
             warnings.filterwarnings("ignore")
             os.environ.setdefault("PYTHONWARNINGS", "ignore")
             os.environ.setdefault("MPLBACKEND", "Agg")
@@ -292,55 +361,19 @@ class DS1000RuntimeNoErrorPotential(Potential):
                     # Unknown harness structure: never kill a prefix we cannot
                     # faithfully execute.
                     print(OK); raise SystemExit(0)
-                solution = answer
-                # Matplotlib harnesses drop plt.show()/savefig/... lines from
-                # the solution before executing it; mirror that here.
-                skip = g.get("skip_plt_cmds")
-                if callable(skip):
-                    solution = "\\n".join(filter(skip, solution.split("\\n")))
-                if solution.endswith("\\\\\\n"):
-                    # Trailing line-continuation: defer to a later boundary.
-                    print(OK); raise SystemExit(0)
                 try:
-                    tree = ast.parse(head + solution, filename="<prefix>", mode="exec")
-                except SyntaxError:
-                    print(SYNTAX); raise SystemExit(0)
-                # A trailing compound statement may still be extended by the
-                # generation: do not execute it yet.
-                if tree.body and hasattr(tree.body[-1], "body"):
-                    tree.body = tree.body[:-1]
-                # Head statements (the head alone may not parse, e.g. a
-                # dangling def) are harness-side; the rest is solution.
-                head_lines = head.count("\\n")
-                n_head = sum(1 for st in tree.body if st.lineno <= head_lines)
-                head_prog = compile(
-                    ast.Module(body=tree.body[:n_head], type_ignores=[]),
-                    "<prefix>",
-                    "exec",
-                )
-                sol_prog = compile(
-                    ast.Module(body=tree.body[n_head:], type_ignores=[]),
-                    "<prefix>",
-                    "exec",
-                )
-                for i in range(n_cases):
-                    # Test-environment setup failures are not the
-                    # solution's fault: defer.
-                    try:
-                        test_input, expected_result = gtc(i + 1)
-                        test_env = {{"test_input": test_input}}
-                        exec(head_prog, test_env)
-                    except Exception:
-                        print(OK); raise SystemExit(0)
-                    exec(sol_prog, test_env)
-                print(OK)
-            except AssertionError:
-                print(OK)
-            except SyntaxError:
-                print(SYNTAX)
+                    test_inputs = [gtc(i + 1)[0] for i in range(n_cases)]
+                except Exception:
+                    # Test-input generation is harness-side: defer.
+                    print(OK); raise SystemExit(0)
+                print(_judge_prefix(
+                    answer, head, g.get("skip_plt_cmds"), test_inputs, OK, BAD, SYNTAX))
+            except SystemExit:
+                raise
             except Exception:
                 print(BAD)
             """
+            )
         ).strip()
 
     async def _run_prefix_script(self, prefix_code, fallback_script, ok, bad, syntax):
@@ -371,9 +404,14 @@ class DS1000RuntimeNoErrorPotential(Potential):
         return await self._run_script(fallback_script)
 
     def _session_setup_script(self) -> str:
-        """Once-per-task session setup: context exec + test-input generation."""
-        return textwrap.dedent(
-            f"""
+        """
+        Once-per-task session setup: define the shared `_judge_prefix`, exec
+        the code_context, and build `head`/`skip`/`test_inputs` for body forks.
+        """
+        return (
+            _PREFIX_JUDGE_SRC
+            + textwrap.dedent(
+                f"""
             import warnings, os
             warnings.filterwarnings("ignore")
             os.environ.setdefault("PYTHONWARNINGS", "ignore")
@@ -389,59 +427,23 @@ class DS1000RuntimeNoErrorPotential(Potential):
                 raise RuntimeError("unknown harness structure")
             skip = g.get("skip_plt_cmds")
             test_inputs = [gtc(i + 1)[0] for i in range(n_cases)]
-            head_lines = head.count("\\n")
             # Warm the head's imports so per-check forks hit sys.modules.
-            for _line in head.split("\\n"):
+            for _line in head.split(chr(10)):
                 if _line.startswith(("import ", "from ")):
                     try:
                         exec(_line, {{}}, {{}})
                     except Exception:
                         pass
             """
+            )
         ).strip()
 
     def _session_body_script(self, prefix_code: str, ok, bad, syntax) -> str:
-        """Per-check body run in a fork of the session (uses its namespace)."""
+        """Per-check body, forked from the session: delegate to `_judge_prefix`."""
         return textwrap.dedent(
             f"""
-            import ast
             OK, BAD, SYNTAX = {ok!r}, {bad!r}, {syntax!r}
-            answer = {prefix_code!r}
-            try:
-                solution = answer
-                if callable(skip):
-                    solution = "\\n".join(filter(skip, solution.split("\\n")))
-                if solution.endswith("\\\\\\n"):
-                    print(OK); raise SystemExit(0)
-                try:
-                    tree = ast.parse(head + solution, filename="<prefix>", mode="exec")
-                except SyntaxError:
-                    print(SYNTAX); raise SystemExit(0)
-                if tree.body and hasattr(tree.body[-1], "body"):
-                    tree.body = tree.body[:-1]
-                n_head = sum(1 for st in tree.body if st.lineno <= head_lines)
-                head_prog = compile(
-                    ast.Module(body=tree.body[:n_head], type_ignores=[]),
-                    "<prefix>", "exec",
-                )
-                sol_prog = compile(
-                    ast.Module(body=tree.body[n_head:], type_ignores=[]),
-                    "<prefix>", "exec",
-                )
-                for ti in test_inputs:
-                    test_env = {{"test_input": ti}}
-                    try:
-                        exec(head_prog, test_env)
-                    except Exception:
-                        print(OK); raise SystemExit(0)
-                    exec(sol_prog, test_env)
-                print(OK)
-            except AssertionError:
-                print(OK)
-            except SyntaxError:
-                print(SYNTAX)
-            except Exception:
-                print(BAD)
+            print(_judge_prefix({prefix_code!r}, head, skip, test_inputs, OK, BAD, SYNTAX))
             """
         ).strip()
 
@@ -474,27 +476,31 @@ class DS1000RuntimeNoErrorPotential(Potential):
                     },
                 )
 
-                try:
-                    proc = await asyncio.create_subprocess_exec(
-                        self.python_executable,
-                        "-B",
-                        path,
-                        stdout=asyncio.subprocess.PIPE,
-                        stderr=asyncio.subprocess.PIPE,
-                        env=env,
-                        cwd=td,
-                    )
-                except OSError:
-                    # fork/pid exhaustion under load: transient, defer
-                    return None
-                try:
-                    stdout_b, stderr_b = await asyncio.wait_for(
-                        proc.communicate(), timeout=self.timeout_seconds
-                    )
-                except asyncio.TimeoutError:
-                    proc.kill()
-                    await proc.communicate()
-                    return None
+                # Hold a slot for the subprocess's whole lifetime so the child
+                # watcher's per-process threads stay bounded under load.
+                async with _subprocess_sem():
+                    try:
+                        proc = await asyncio.create_subprocess_exec(
+                            self.python_executable,
+                            "-B",
+                            path,
+                            stdout=asyncio.subprocess.PIPE,
+                            stderr=asyncio.subprocess.PIPE,
+                            env=env,
+                            cwd=td,
+                        )
+                    except (OSError, RuntimeError):
+                        # fork/pid/thread exhaustion under load ("can't start
+                        # new thread" is a RuntimeError): transient, defer.
+                        return None
+                    try:
+                        stdout_b, stderr_b = await asyncio.wait_for(
+                            proc.communicate(), timeout=self.timeout_seconds
+                        )
+                    except asyncio.TimeoutError:
+                        proc.kill()
+                        await proc.communicate()
+                        return None
         except subprocess.TimeoutExpired:
             return None
 
@@ -504,8 +510,8 @@ class DS1000RuntimeNoErrorPotential(Potential):
 
     async def _score_no_error(self, complete_code: str, mode: str = "complete") -> float:
         """
-        Run the harness script in a subprocess: 0.0 if no error (incl.
-        AssertionError), -inf otherwise. mode="complete" runs the full
+        Run the harness script (fork-server or subprocess): 0.0 if no error
+        (incl. AssertionError), -inf otherwise. mode="complete" runs the full
         test_execution harness; "prefix" only the context head + solution.
         """
         cache_key = (mode, complete_code)

--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -74,15 +74,11 @@ def _exec_context_head(code_context: str):
 
 class DS1000RuntimeNoErrorPotential(Potential):
     """
-    DS-1000 expensive potential: execute the harness on a code prefix or a
-    complete solution. Return 0.0 if no error, -inf otherwise.
-
-    prefix() asks "can this prefix still extend to a valid solution": it
-    executes only `exec_context` up to `[insert]` plus the partial solution,
-    skipping the answer checks (result extraction, exec_test, context tail)
-    that a partial solution legitimately cannot satisfy yet; syntactically
-    incomplete prefixes are deferred (0.0). complete() runs the full
-    `test_execution` harness; any non-assertion error is -inf.
+    DS-1000 expensive potential: 0.0 if the harness raises no error, -inf
+    otherwise. prefix() executes only exec_context up to [insert] plus the
+    partial solution, skipping answer checks a partial solution cannot
+    satisfy yet; incomplete syntax defers. complete() runs the full
+    test_execution harness; any non-assertion error is -inf.
     """
 
     def __init__(
@@ -107,11 +103,9 @@ class DS1000RuntimeNoErrorPotential(Potential):
         # strict_prefix=True scores prefixes with the full harness (answer
         # checks included) instead of the head-only check.
         self.strict_prefix = bool(strict_prefix)
-        # use_forkserver=True runs harness scripts through a warm fork-server
-        # (one shared worker per python executable) instead of a fresh
-        # subprocess per check; on any backend failure it falls back to the
-        # subprocess path. Note: env vars read at interpreter startup (e.g.
-        # PYTHONHASHSEED) only take effect at worker start.
+        # use_forkserver=True: warm fork-server instead of a subprocess per
+        # check, with subprocess fallback on backend failure. Startup-time env
+        # vars (e.g. PYTHONHASHSEED) only apply at worker start.
         self.use_forkserver = bool(use_forkserver)
         self._n_test_cases = _test_case_count(code_context)
         self._ec_head, self._ec_block_insert = _exec_context_head(code_context)
@@ -122,10 +116,8 @@ class DS1000RuntimeNoErrorPotential(Potential):
         # statements, so defer them without paying the timeout again.
         self._hung_prefixes = []
         self._hung_prefixes_maxsize = 16
-        # SMC frequently clones particles into identical or repeated prefixes.
-        # Cache exact postprocessed code strings to avoid launching duplicate
-        # DS1000 subprocess checks. The cache is per potential instance, whose
-        # code_context / timeout / environment are fixed.
+        # SMC clones particles into repeated prefixes; cache verdicts per
+        # exact postprocessed code (instance config is fixed).
         self._score_cache = OrderedDict()
         self._score_cache_maxsize = 4096
         self.cache_hits = 0
@@ -155,9 +147,7 @@ class DS1000RuntimeNoErrorPotential(Potential):
             return toks
         if isinstance(toks, bytes):
             return toks.decode("utf-8", errors="ignore")
-        # genlm-control/vLLM contexts may be either byte tokens or integer byte ids.
-        # Normalize both forms before decoding so the potential is robust across
-        # backend/token-map representations.
+        # Contexts may be byte tokens or integer byte ids; normalize both.
         byte_pieces = []
         for tok in toks:
             if isinstance(tok, int):
@@ -218,9 +208,7 @@ class DS1000RuntimeNoErrorPotential(Potential):
             context = self.f(context)
         code = self._bytes_to_str(context)
         code = _postprocess_code(code)
-        # Empty completion don't define `result`, so the harness will
-        # always raise KeyError. Skip the subprocess and return -inf directly.
-        # The LM often emits EOS / "</code>" as the first token.
+        # Empty completions never define `result`; skip the subprocess.
         if not code:
             return float("-inf")
         out = await self._score_no_error(code, mode="complete")
@@ -317,14 +305,12 @@ class DS1000RuntimeNoErrorPotential(Potential):
                     tree = ast.parse(head + solution, filename="<prefix>", mode="exec")
                 except SyntaxError:
                     print(SYNTAX); raise SystemExit(0)
-                # A trailing compound statement (for/if/def/... -- anything with
-                # a body) may still be extended by the generation, so executing
-                # it now could raise errors the full solution would not.
+                # A trailing compound statement may still be extended by the
+                # generation: do not execute it yet.
                 if tree.body and hasattr(tree.body[-1], "body"):
                     tree.body = tree.body[:-1]
-                # Statements starting within the head (which alone may not
-                # parse, e.g. a dangling def the solution completes) are
-                # harness-side; the rest belong to the solution.
+                # Head statements (the head alone may not parse, e.g. a
+                # dangling def) are harness-side; the rest is solution.
                 head_lines = head.count("\\n")
                 n_head = sum(1 for st in tree.body if st.lineno <= head_lines)
                 head_prog = compile(
@@ -338,9 +324,8 @@ class DS1000RuntimeNoErrorPotential(Potential):
                     "exec",
                 )
                 for i in range(n_cases):
-                    # Failures while building the test environment (some
-                    # harnesses set up files etc. inside test_execution) are
-                    # not the solution's fault: defer.
+                    # Test-environment setup failures are not the
+                    # solution's fault: defer.
                     try:
                         test_input, expected_result = gtc(i + 1)
                         test_env = {{"test_input": test_input}}

--- a/genlm/eval/domains/ds1000/runtime_no_error_potential.py
+++ b/genlm/eval/domains/ds1000/runtime_no_error_potential.py
@@ -116,11 +116,9 @@ def _test_case_count(code_context: str) -> int:
 
 def _exec_context_head(code_context: str):
     """
-    Return (head, is_block_insert): the exec_context source before the
-    `[insert]` line (None if not found), and whether `[insert]` stands alone
-    on its line. Some problems insert the solution as an indented function
-    body that only parses together with the head; inline inserts (e.g.
-    `[insert].numpy()`) cannot be partially executed at all.
+    Return (head, is_block_insert): exec_context before the `[insert]` line
+    (None if absent), and whether `[insert]` is on its own line (vs inline,
+    e.g. `[insert].numpy()`).
     """
     m = re.search(r"exec_context\s*=\s*r?(\"\"\"|''')(.*?)\1", code_context, re.S)
     if not m:
@@ -138,11 +136,9 @@ def _exec_context_head(code_context: str):
 
 class DS1000RuntimeNoErrorPotential(Potential):
     """
-    DS-1000 expensive potential: 0.0 if the harness raises no error, -inf
-    otherwise. prefix() executes only exec_context up to [insert] plus the
-    partial solution, skipping answer checks a partial solution cannot
-    satisfy yet; incomplete syntax defers. complete() runs the full
-    test_execution harness; any non-assertion error is -inf.
+    DS-1000 potential: 0.0 if the harness raises no error, -inf otherwise.
+    prefix() runs exec_context-head + partial solution (no answer checks);
+    complete() runs the full test_execution harness.
     """
 
     def __init__(

--- a/tests/test_ds1000.py
+++ b/tests/test_ds1000.py
@@ -197,10 +197,17 @@ async def test_runtime_potential_gating_requires_trailing_newline_and_parsable()
     score1 = await pot.prefix([s1.encode()])
     assert score1 == 0.0
 
-    # Trailing newline but syntactically incomplete -> return 0.0
+    # Trailing newline but syntactically incomplete: a continuation can still
+    # close the paren, so judgment is deferred (0.0), not -inf.
     s2 = "def foo(\n"
     score2 = await pot.prefix([s2.encode()])
-    assert score2 == float("-inf")
+    assert score2 == 0.0
+
+    # Unfixable syntax error -> -inf at the prefix already.
+    s2b = "definitely not valid python !\n"
+    score2b = await pot.prefix([s2b.encode()])
+    assert score2b == float("-inf")
+    assert pot.last_was_syntax_error is True
 
     # Proper code -> executes harness -> OK
     s3 = "def foo():\n    return 42\n"
@@ -220,21 +227,27 @@ async def test_runtime_potential_cache_replays_value_and_syntax_flag():
     pot = DS1000RuntimeNoErrorPotential(
         code_context=harness_expect_foo_eq_42(), timeout_seconds=0.5
     )
-    bad_syntax = "def foo(\n"                  # -> -inf, syntax_error=True
+    bad_syntax = "definitely not valid python !\n"  # -> -inf, syntax_error=True (host-side)
     good = "def foo():\n    return 42\n"       # -> 0.0,  syntax_error=False
 
     s1 = await pot.prefix([bad_syntax.encode()])
     assert s1 == float("-inf") and pot.last_was_syntax_error is True
     s2 = await pot.prefix([good.encode()])
     assert s2 == 0.0 and pot.last_was_syntax_error is False
-    assert pot.cache_hits == 0 and pot.cache_misses == 2
+    # broken syntax is rejected host-side without a subprocess; only the good
+    # prefix reaches the scorer.
+    assert pot.cache_hits == 0 and pot.cache_misses == 1
 
     # Replay: must hit cache and restore the per-call flag correctly.
     s3 = await pot.prefix([bad_syntax.encode()])
     assert s3 == float("-inf") and pot.last_was_syntax_error is True
     s4 = await pot.prefix([good.encode()])
     assert s4 == 0.0 and pot.last_was_syntax_error is False
-    assert pot.cache_hits == 2 and pot.cache_misses == 2
+    assert pot.cache_hits == 1 and pot.cache_misses == 1
+
+    # complete() still scores broken syntax through the subprocess path.
+    s5 = await pot.complete([bad_syntax.encode()])
+    assert s5 == float("-inf") and pot.last_was_syntax_error is True
 
 
 @pytest.mark.asyncio
@@ -296,6 +309,454 @@ def test_harness_timeout_in_test_execution(evaluator):
     instance = make_instance(code_context)
     res = evaluator.evaluate_sample(instance, "def foo():\n    return 42\n")
     assert res.score == 0.0
+
+
+# ----------------------------------------- #
+# Prefix semantics on a DS-1000-like harness #
+# ----------------------------------------- #
+
+# Mirrors the structure of real DS-1000 code contexts: an exec_context with an
+# [insert] placeholder and a tail that references a variable the solution must
+# define, and a test_execution that extracts
+# test_env["result"] after execution.
+DS1000_LIKE_CONTEXT = '''
+import copy
+
+
+def generate_test_case(test_case_id):
+    def generate_ans(data):
+        return sorted(data)
+
+    def define_test_input(test_case_id):
+        return [3, 1, 2]
+
+    test_input = define_test_input(test_case_id)
+    expected_result = generate_ans(copy.deepcopy(test_input))
+    return test_input, expected_result
+
+
+def exec_test(result, ans):
+    assert result == ans
+    return 1
+
+
+exec_context = r"""
+data = test_input
+[insert]
+result = answer_list
+"""
+
+
+def test_execution(solution: str):
+    code = exec_context.replace("[insert]", solution)
+    for i in range(1):
+        test_input, expected_result = generate_test_case(i + 1)
+        test_env = {"test_input": test_input}
+        exec(code, test_env)
+        assert exec_test(test_env["result"], expected_result)
+'''
+
+
+@pytest.fixture
+def ds1000_like_potential():
+    return DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_prefix_survives_partial_multiline_solution(ds1000_like_potential):
+    # First line of a correct two-line solution: does not define `answer_list`
+    # yet, so the exec_context tail / result extraction would raise
+    # NameError/KeyError. The prefix must NOT be killed.
+    score = await ds1000_like_potential.prefix([b"tmp = list(data)\n"])
+    assert score == 0.0
+    # ... and the full solution passes prefix and complete.
+    full = "tmp = list(data)\nanswer_list = sorted(tmp)\n"
+    assert await ds1000_like_potential.prefix([full.encode()]) == 0.0
+    assert await ds1000_like_potential.complete([full.encode()]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_prefix_defers_open_block_then_checks_when_closed(ds1000_like_potential):
+    pot = ds1000_like_potential
+    # Open for-loop: syntactically incomplete -> defer.
+    assert await pot.prefix([b"answer_list = []\nfor v in sorted(data):\n"]) == 0.0
+    # Body present but loop still extendable -> trailing compound is skipped.
+    s = b"answer_list = []\nfor v in sorted(data):\n    answer_list.append(v)\n"
+    assert await pot.prefix([s]) == 0.0
+    # Once a top-level statement follows, the loop is closed and executes.
+    s_err = (
+        b"answer_list = []\n"
+        b"for v in sorted(data):\n"
+        b"    answer_list.append(undefined_name)\n"
+        b"x = 1\n"
+    )
+    assert await pot.prefix([s_err]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_terminal_marker_applies_strict_check(ds1000_like_potential):
+    pot = ds1000_like_potential
+    # After </code> the postprocessed solution is final: a missing answer
+    # variable is now a definitive failure, not a deferrable prefix state.
+    assert await pot.prefix([b"tmp = list(data)\n</code>\n"]) == float("-inf")
+    assert await pot.prefix([b"answer_list = sorted(data)\n</code>\n"]) == 0.0
+    assert await pot.prefix([b"answer_list = sorted(data)\nEND SOLUTION\n"]) == 0.0
+    assert await pot.prefix([b"tmp = 1\nEND SOLUTION\n"]) == float("-inf")
+    # A terminally-empty generation can never become a solution.
+    assert await pot.prefix([b"</code>\n"]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_hung_prefix_extensions_skip_subprocess(ds1000_like_potential):
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=4.0
+    )
+    calls = []
+    orig = pot._run_script
+
+    async def counting(script):
+        calls.append(1)
+        return await orig(script)
+
+    pot._run_script = counting
+    hang = b"while True:\n    pass\nx = 1\n"
+    assert await pot.prefix([hang]) == 0.0
+    n = len(calls)
+    assert n >= 1
+    # Extending a hung prefix re-runs the same leading statements: defer
+    # without launching another subprocess.
+    assert await pot.prefix([hang + b"y = 2\n"]) == 0.0
+    assert len(calls) == n
+
+
+@pytest.fixture
+def fast_forkserver_env(monkeypatch):
+    # Skip heavy pre-imports so worker warmup is instant in tests.
+    monkeypatch.setenv("DS1000_FORKSERVER_PRELOAD", "")
+
+
+@pytest.mark.asyncio
+async def test_forkserver_backend_matches_subprocess_verdicts(fast_forkserver_env):
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=True
+    )
+    assert await pot.prefix([b"tmp = list(data)\n"]) == 0.0
+    full = b"tmp = list(data)\nanswer_list = sorted(tmp)\n"
+    assert await pot.prefix([full]) == 0.0
+    assert await pot.complete([full]) == 0.0
+    assert await pot.complete([b"tmp = list(data)\n"]) == float("-inf")
+    assert await pot.prefix([b"import nonexistent_module_xyz\n"]) == float("-inf")
+
+
+def test_session_scripts_are_valid_python():
+    # Template escaping bugs silently degrade to the (slow) fallback path,
+    # so the generated session scripts must always parse.
+    import ast as _ast
+
+    for ctx in (DS1000_LIKE_CONTEXT, FUNCTION_BODY_CONTEXT, MATPLOTLIB_LIKE_CONTEXT):
+        pot = DS1000RuntimeNoErrorPotential(code_context=ctx)
+        _ast.parse(pot._session_setup_script())
+        _ast.parse(pot._session_body_script("x = 1\n", "<OK>", "<BAD>", "<SYN>"))
+        _ast.parse(pot._prefix_script("x = 1\n", "<OK>", "<BAD>", "<SYN>"))
+        _ast.parse(pot._complete_script("x = 1\n", "<OK>", "<BAD>", "<SYN>"))
+
+
+@pytest.mark.asyncio
+async def test_session_function_body_and_errors(fast_forkserver_env):
+    # Function-body solutions through the warm-session path: the head only
+    # parses combined with the solution, so the body script must reproduce
+    # the line-attribution logic.
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=FUNCTION_BODY_CONTEXT, timeout_seconds=10.0, use_forkserver=True
+    )
+    assert await pot.prefix([b"    return sorted(data)\n"]) == 0.0
+    assert await pot.prefix([b"    definitely not valid python !\n"]) == float(
+        "-inf"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_setup_failure_falls_back(fast_forkserver_env):
+    # FILE_SETUP_CONTEXT's generate_test_case fails outside test_execution
+    # (missing file), so the session setup fails; the worker must serve the
+    # request via the stateless fallback, which defers (0.0).
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=FILE_SETUP_CONTEXT, timeout_seconds=10.0, use_forkserver=True
+    )
+    assert await pot.prefix([b"answer_list = sorted(data)\n"]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_sessions_disabled_knob(fast_forkserver_env, monkeypatch):
+    monkeypatch.setenv("DS1000_FORKSERVER_SESSIONS", "0")
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=True
+    )
+    assert await pot.prefix([b"tmp = list(data)\n"]) == 0.0
+    assert await pot.prefix([b"import nonexistent_module_xyz\n"]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_forkserver_falls_back_to_subprocess(fast_forkserver_env, monkeypatch):
+    from genlm.eval.domains.ds1000 import forkserver as fs
+
+    # Unstartable worker: the potential must still answer via subprocess.
+    monkeypatch.setattr(fs, "_WORKER_PATH", "/nonexistent/worker.py")
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=True
+    )
+    full = b"tmp = list(data)\nanswer_list = sorted(tmp)\n"
+    assert await pot.complete([full]) == 0.0
+    assert await pot.complete([b"tmp = list(data)\n"]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_forkserver_worker_death_falls_back(fast_forkserver_env):
+    from genlm.eval.domains.ds1000.forkserver import shared_executor
+
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=True
+    )
+    full = b"tmp = list(data)\nanswer_list = sorted(tmp)\n"
+    assert await pot.complete([full]) == 0.0
+    # Kill the shared worker mid-session: subsequent calls must not crash
+    # (restart or subprocess fallback) and verdicts stay correct.
+    executor = shared_executor(pot.python_executable, pot.extra_env)
+    executor.kill()
+    assert await pot.complete([b"tmp = list(data)\n"]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_prefix_defers_trailing_backslash_continuation(ds1000_like_potential):
+    pot = ds1000_like_potential
+    # A trailing line-continuation can be completed by the next line.
+    assert await pot.prefix([b"answer_list = \\\n"]) == 0.0
+    full = b"answer_list = \\\n    sorted(data)\n"
+    assert await pot.prefix([full]) == 0.0
+    assert await pot.complete([full]) == 0.0
+
+
+# The harness writes a file inside test_execution before its test loop;
+# generate_test_case reads it. Prefix checks cannot replicate that setup, so
+# environment failures while building the test inputs must defer, not kill.
+FILE_SETUP_CONTEXT = '''
+def generate_test_case(test_case_id):
+    with open("data.txt") as fh:
+        data = [int(x) for x in fh.read().split()]
+    return data, sorted(data)
+
+
+def exec_test(result, ans):
+    assert result == ans
+    return 1
+
+
+exec_context = r"""
+data = test_input
+[insert]
+result = answer_list
+"""
+
+
+def test_execution(solution: str):
+    with open("data.txt", "w") as fh:
+        fh.write("3 1 2")
+    code = exec_context.replace("[insert]", solution)
+    for i in range(1):
+        test_input, expected_result = generate_test_case(i + 1)
+        test_env = {"test_input": test_input}
+        exec(code, test_env)
+        assert exec_test(test_env["result"], expected_result)
+'''
+
+
+@pytest.mark.asyncio
+async def test_prefix_defers_harness_side_setup_failures():
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=FILE_SETUP_CONTEXT, timeout_seconds=10.0
+    )
+    sol = b"answer_list = sorted(data)\n"
+    assert await pot.prefix([sol]) == 0.0
+    assert await pot.complete([sol]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_prefix_timeout_defers_complete_timeout_kills():
+    # A slow prefix may still have a valid continuation: prefix defers (0.0),
+    # only complete() treats the timeout as fatal.
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=5.0
+    )
+    hang = b"while True:\n    pass\nx = 1\n"
+    assert await pot.prefix([hang]) == 0.0
+    assert await pot.complete([hang]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_prefix_kills_real_runtime_errors(ds1000_like_potential):
+    # Genuine error in already-complete statements: no continuation can fix it.
+    score = await ds1000_like_potential.prefix(
+        [b"import nonexistent_module_xyz\n"]
+    )
+    assert score == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_prefix_does_not_execute_trailing_compound(ds1000_like_potential):
+    # The trailing loop raises if executed, but the generation may still
+    # extend its body, so the prefix must not be killed.
+    s = b"for v in data:\n    raise ValueError(v)\n"
+    assert await ds1000_like_potential.prefix([s]) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_complete_still_requires_answer_variable(ds1000_like_potential):
+    # complete() keeps strict harness semantics: missing `answer_list`
+    # (and hence `result`) is an error.
+    assert await ds1000_like_potential.complete([b"tmp = list(data)\n"]) == float(
+        "-inf"
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_prefix_runs_full_harness_on_prefixes(ds1000_like_potential):
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, strict_prefix=True
+    )
+    # The full harness kills the partial solution (NameError on the
+    # exec_context tail).
+    assert await pot.prefix([b"tmp = list(data)\n"]) == float("-inf")
+
+
+# Mirrors the matplotlib problems: exec_context sets up the "figure" state and
+# the solution mutates it; exec_test then inspects state the solution may not
+# have produced yet (a half-drawn plot has no legend -> None subscription).
+MATPLOTLIB_LIKE_CONTEXT = '''
+def skip_plt_cmds(l):
+    return all(p not in l for p in ["plt.show()", "plt.clf()", "plt.close()", "savefig"])
+
+
+def generate_test_case(test_case_id):
+    return None, None
+
+
+def exec_test(result, ans):
+    leg = result.get("legend")
+    assert leg[0] == "x-y"  # TypeError on half-drawn plot (legend is None)
+    return 1
+
+
+exec_context = r"""
+_state = {}
+
+
+def plot(x):
+    _state["plotted"] = True
+
+
+def legend(labels):
+    _state["legend"] = list(labels)
+
+
+[insert]
+result = _state
+"""
+
+
+def test_execution(solution: str):
+    solution = "\\n".join(filter(skip_plt_cmds, solution.split("\\n")))
+    code = exec_context.replace("[insert]", solution)
+    for i in range(1):
+        test_input, expected_result = generate_test_case(i + 1)
+        test_env = {"test_input": test_input}
+        exec(code, test_env)
+        assert exec_test(test_env["result"], expected_result)
+'''
+
+
+# Mirrors the function-completion problems: the solution is an
+# *indented* function body inserted inside `def f(...):`, so it does not parse
+# standalone, and the exec_context tail calls the function.
+FUNCTION_BODY_CONTEXT = '''
+import copy
+
+
+def generate_test_case(test_case_id):
+    def generate_ans(data):
+        return sorted(data)
+
+    def define_test_input(test_case_id):
+        return [3, 1, 2]
+
+    test_input = define_test_input(test_case_id)
+    expected_result = generate_ans(copy.deepcopy(test_input))
+    return test_input, expected_result
+
+
+def exec_test(result, ans):
+    assert result == ans
+    return 1
+
+
+exec_context = r"""
+data = test_input
+def f(data):
+[insert]
+result = f(data)
+"""
+
+
+def test_execution(solution: str):
+    code = exec_context.replace("[insert]", solution)
+    for i in range(1):
+        test_input, expected_result = generate_test_case(i + 1)
+        test_env = {"test_input": test_input}
+        exec(code, test_env)
+        assert exec_test(test_env["result"], expected_result)
+'''
+
+
+@pytest.mark.asyncio
+async def test_function_body_solutions_parse_with_context():
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=FUNCTION_BODY_CONTEXT, timeout_seconds=10.0
+    )
+    # An indented body does not parse standalone but must NOT be killed:
+    # neither at the prefix nor at complete().
+    body = b"    return sorted(data)\n"
+    assert await pot.prefix([body]) == 0.0
+    assert await pot.complete([body]) == 0.0
+    # Multi-line body, first line only -> prefix defers/passes.
+    partial = b"    tmp = list(data)\n"
+    assert await pot.prefix([partial]) == 0.0
+    full = b"    tmp = list(data)\n    return sorted(tmp)\n"
+    assert await pot.prefix([full]) == 0.0
+    assert await pot.complete([full]) == 0.0
+    # Garbage inside the body is still rejected.
+    assert await pot.prefix([b"    definitely not valid python !\n"]) == float(
+        "-inf"
+    )
+    # A body that errors at call time is caught at complete()
+    # (the def itself is the trailing compound, so prefix cannot judge it).
+    assert await pot.complete([b"    return undefined_name_xyz\n"]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_prefix_skips_figure_inspection_on_half_drawn_plot():
+    # Mirrors the matplotlib failure mode: exec_test inspects the legend,
+    # which does not exist yet after only the plot call. The prefix must not
+    # run exec_test; complete() must.
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=MATPLOTLIB_LIKE_CONTEXT, timeout_seconds=10.0
+    )
+    assert await pot.prefix([b"plot([1, 2])\n"]) == 0.0
+    full = b"plot([1, 2])\nlegend(['x-y'])\n"
+    assert await pot.prefix([full]) == 0.0
+    assert await pot.complete([full]) == 0.0
+    # Without the legend the complete harness errors (TypeError on None).
+    assert await pot.complete([b"plot([1, 2])\n"]) == float("-inf")
 
 
 @pytest.mark.parametrize("context", [[], list(b"</code>")])

--- a/tests/test_ds1000.py
+++ b/tests/test_ds1000.py
@@ -38,9 +38,26 @@ def harness_expect_foo_eq_43() -> str:
     )
 
 
+@pytest.fixture(autouse=True)
+def _fast_forkserver_warmup(monkeypatch):
+    # The potential defaults to the fork-server backend; skip the heavy
+    # science pre-imports so test workers warm in well under a second.
+    monkeypatch.setenv("DS1000_FORKSERVER_PRELOAD", "")
+    yield
+    # Each async test runs on its own event loop; kill any worker bound to it
+    # so no subprocess transport survives into a closed loop (avoids cross-test
+    # flakiness and asyncio GC noise).
+    from genlm.eval.domains.ds1000 import forkserver as _fs
+
+    for ex in list(_fs._executors.values()):
+        ex.kill()
+    _fs._executors.clear()
+
+
 @pytest.fixture
 def evaluator():
-    return DS1000Evaluator(timeout_seconds=0.2)
+    # Generous: a tight budget flakes on slow interpreter startup under load.
+    return DS1000Evaluator(timeout_seconds=15.0)
 
 # ------------------------------ #
 # DS1000Dataset                  #
@@ -120,7 +137,6 @@ def test_evaluate_sample_fail_when_harness_fails(evaluator):
     instance = make_instance(harness_expect_foo_eq_43())
     res = evaluator.evaluate_sample(instance, "def foo():\n    return 42\n")
     assert res.score == 0.0
-    assert ("fail" in res.desc.lower()) or ("wrong" in res.desc.lower()) or res.desc.strip().startswith("def foo()")
 
 
 def test_run_in_subprocess_pass_and_fail_markers(evaluator):
@@ -155,13 +171,14 @@ def test_run_in_subprocess_uses_extra_env(evaluator, monkeypatch):
 # ------------------------------ #
 
 @pytest.mark.asyncio
-async def test_runtime_potential_ok_on_assertion_failure_treated_as_ok():
-    pot = DS1000RuntimeNoErrorPotential(code_context=harness_expect_foo_eq_43(), timeout_seconds=0.5)
-    # wrong answer -> treated as OK by the potential
-    solution = "def foo():\n    return 42\n\n"
-    ctx = [solution.encode()]
-    score = await pot.prefix(ctx)
-    assert score == 0.0  # OK case
+async def test_complete_tolerates_wrong_answer():
+    # The potential scores "no runtime error", not correctness: a solution
+    # that runs but gives the wrong answer (AssertionError in exec_test) is OK.
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0
+    )
+    wrong = b"answer_list = list(data)\n"  # unsorted: runs, fails exec_test
+    assert await pot.complete([wrong]) == 0.0
 
 
 @pytest.mark.asyncio
@@ -171,20 +188,6 @@ async def test_runtime_potential_bad_on_exception_in_harness_call():
     solution = "def foo():\n    raise RuntimeError('boom')\n\n"
     ctx = [solution.encode()]
     score = await pot.complete(ctx)
-    assert score == float("-inf")
-
-
-@pytest.mark.asyncio
-async def test_runtime_potential_timeout(monkeypatch):
-    # Harness with infinite loop -> timeout -> -inf
-    code_context = (
-        "def test_execution(solution):\n"
-        "    while True:\n"
-        "        pass\n"
-    )
-    pot = DS1000RuntimeNoErrorPotential(code_context=code_context, timeout_seconds=0.2)
-    solution = "x = 1\n\n"
-    score = await pot.complete([solution.encode()])
     assert score == float("-inf")
 
 
@@ -208,11 +211,6 @@ async def test_runtime_potential_gating_requires_trailing_newline_and_parsable()
     score2b = await pot.prefix([s2b.encode()])
     assert score2b == float("-inf")
     assert pot.last_was_syntax_error is True
-
-    # Proper code -> executes harness -> OK
-    s3 = "def foo():\n    return 42\n"
-    score3 = await pot.prefix([s3.encode()])
-    assert score3 == 0.0
 
 
 def test_runtime_potential_coerce_adopts_vocab():
@@ -300,7 +298,9 @@ def test_harness_top_level_exec_error(evaluator):
     assert res.score == 0.0
 
 
-def test_harness_timeout_in_test_execution(evaluator):
+def test_harness_timeout_in_test_execution():
+    # Short budget: the timeout must fire on the infinite loop.
+    evaluator = DS1000Evaluator(timeout_seconds=1.0)
     code_context = (
         "def test_execution(solution):\n"
         "    while True:\n"
@@ -410,8 +410,10 @@ async def test_terminal_marker_applies_strict_check(ds1000_like_potential):
 
 @pytest.mark.asyncio
 async def test_hung_prefix_extensions_skip_subprocess(ds1000_like_potential):
+    # Hung-prefix memoization lives in _score_no_error (backend-agnostic);
+    # pin the subprocess path so _run_script is the execution call we count.
     pot = DS1000RuntimeNoErrorPotential(
-        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=4.0
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=4.0, use_forkserver=False
     )
     calls = []
     orig = pot._run_script
@@ -426,7 +428,7 @@ async def test_hung_prefix_extensions_skip_subprocess(ds1000_like_potential):
     n = len(calls)
     assert n >= 1
     # Extending a hung prefix re-runs the same leading statements: defer
-    # without launching another subprocess.
+    # without launching another check.
     assert await pot.prefix([hang + b"y = 2\n"]) == 0.0
     assert len(calls) == n
 
@@ -435,19 +437,6 @@ async def test_hung_prefix_extensions_skip_subprocess(ds1000_like_potential):
 def fast_forkserver_env(monkeypatch):
     # Skip heavy pre-imports so worker warmup is instant in tests.
     monkeypatch.setenv("DS1000_FORKSERVER_PRELOAD", "")
-
-
-@pytest.mark.asyncio
-async def test_forkserver_backend_matches_subprocess_verdicts(fast_forkserver_env):
-    pot = DS1000RuntimeNoErrorPotential(
-        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=True
-    )
-    assert await pot.prefix([b"tmp = list(data)\n"]) == 0.0
-    full = b"tmp = list(data)\nanswer_list = sorted(tmp)\n"
-    assert await pot.prefix([full]) == 0.0
-    assert await pot.complete([full]) == 0.0
-    assert await pot.complete([b"tmp = list(data)\n"]) == float("-inf")
-    assert await pot.prefix([b"import nonexistent_module_xyz\n"]) == float("-inf")
 
 
 def test_session_scripts_are_valid_python():
@@ -461,20 +450,6 @@ def test_session_scripts_are_valid_python():
         _ast.parse(pot._session_body_script("x = 1\n", "<OK>", "<BAD>", "<SYN>"))
         _ast.parse(pot._prefix_script("x = 1\n", "<OK>", "<BAD>", "<SYN>"))
         _ast.parse(pot._complete_script("x = 1\n", "<OK>", "<BAD>", "<SYN>"))
-
-
-@pytest.mark.asyncio
-async def test_session_function_body_and_errors(fast_forkserver_env):
-    # Function-body solutions through the warm-session path: the head only
-    # parses combined with the solution, so the body script must reproduce
-    # the line-attribution logic.
-    pot = DS1000RuntimeNoErrorPotential(
-        code_context=FUNCTION_BODY_CONTEXT, timeout_seconds=10.0, use_forkserver=True
-    )
-    assert await pot.prefix([b"    return sorted(data)\n"]) == 0.0
-    assert await pot.prefix([b"    definitely not valid python !\n"]) == float(
-        "-inf"
-    )
 
 
 @pytest.mark.asyncio
@@ -526,6 +501,92 @@ async def test_forkserver_worker_death_falls_back(fast_forkserver_env):
     executor = shared_executor(pot.python_executable, pot.extra_env)
     executor.kill()
     assert await pot.complete([b"tmp = list(data)\n"]) == float("-inf")
+
+
+def test_forkserver_is_default():
+    pot = DS1000RuntimeNoErrorPotential(code_context=DS1000_LIKE_CONTEXT)
+    assert pot.use_forkserver is True
+
+
+@pytest.mark.asyncio
+async def test_subprocess_concurrency_is_bounded(monkeypatch):
+    # Many concurrent subprocess-path checks must stay within the cap (so the
+    # child watcher's per-process threads can't exhaust) and all return the
+    # right verdict.
+    import asyncio as aio
+    from genlm.eval.domains.ds1000 import runtime_no_error_potential as rne
+
+    monkeypatch.setenv("DS1000_SUBPROCESS_CONCURRENCY", "3")
+    rne._subprocess_sems.clear()
+
+    live = {"n": 0, "peak": 0}
+    real = aio.create_subprocess_exec
+
+    async def tracking(*a, **k):
+        live["n"] += 1
+        live["peak"] = max(live["peak"], live["n"])
+        proc = await real(*a, **k)
+        _orig_comm = proc.communicate
+
+        async def comm():
+            try:
+                return await _orig_comm()
+            finally:
+                live["n"] -= 1
+
+        proc.communicate = comm
+        return proc
+
+    monkeypatch.setattr(aio, "create_subprocess_exec", tracking)
+    pot = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=False
+    )
+    # Distinct (still correct) solutions so each misses the verdict cache and
+    # actually launches a concurrent subprocess.
+    codes = [f"answer_list = sorted(data)  # {i}\n".encode() for i in range(12)]
+    results = await aio.gather(*[pot.complete([c]) for c in codes])
+    assert all(r == 0.0 for r in results)
+    assert 1 < live["peak"] <= 3
+
+
+def test_tensorflow_context_forces_subprocess():
+    # TF is unsafe to import in a forked child, so TF problems must not use the
+    # fork-server even when it is requested/default.
+    tf_ctx = "import tensorflow as tf\n" + DS1000_LIKE_CONTEXT
+    pot = DS1000RuntimeNoErrorPotential(code_context=tf_ctx, use_forkserver=True)
+    assert pot._fork_unsafe is True
+    assert pot.use_forkserver is False
+    assert pot.coerce(SimpleNamespace(vocab=[b"a"])).use_forkserver is False
+
+
+def test_forkserver_killswitch_env_forces_subprocess(monkeypatch):
+    # DS1000_FORKSERVER=0 forces the subprocess path even on the default.
+    monkeypatch.setenv("DS1000_FORKSERVER", "0")
+    pot = DS1000RuntimeNoErrorPotential(code_context=DS1000_LIKE_CONTEXT)
+    assert pot.use_forkserver is False
+    # ...and survives coerce.
+    other = SimpleNamespace(vocab=[b"a", b"b"])
+    assert pot.coerce(other).use_forkserver is False
+
+
+@pytest.mark.asyncio
+async def test_default_backend_matches_subprocess(ds1000_like_potential):
+    # The default (fork-server) and the forced-subprocess path agree.
+    default = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0
+    )
+    sub = DS1000RuntimeNoErrorPotential(
+        code_context=DS1000_LIKE_CONTEXT, timeout_seconds=10.0, use_forkserver=False
+    )
+    for code in (
+        b"tmp = list(data)\n",
+        b"answer_list = sorted(data)\n",
+        b"import nonexistent_module_xyz\n",
+        b"answer_list = []\nfor v in sorted(data):\n",
+    ):
+        assert await default.prefix([code]) == await sub.prefix([code])
+    full = b"answer_list = sorted(data)\n"
+    assert await default.complete([full]) == await sub.complete([full]) == 0.0
 
 
 @pytest.mark.asyncio
@@ -757,6 +818,25 @@ async def test_prefix_skips_figure_inspection_on_half_drawn_plot():
     assert await pot.complete([full]) == 0.0
     # Without the legend the complete harness errors (TypeError on None).
     assert await pot.complete([b"plot([1, 2])\n"]) == float("-inf")
+
+
+@pytest.mark.asyncio
+async def test_complete_ok_implies_no_prefix_kill():
+    # Soundness invariant: if complete() judges a generation OK (0.0), then no
+    # line-boundary prefix of it may be killed (-inf). Covers correct and
+    # wrong-but-running answers across the function-body and matplotlib shapes.
+    cases = [
+        (DS1000_LIKE_CONTEXT, "tmp = list(data)\nanswer_list = sorted(tmp)\n"),
+        (DS1000_LIKE_CONTEXT, "tmp = list(data)\nanswer_list = tmp\n"),  # wrong, runs
+        (FUNCTION_BODY_CONTEXT, "    tmp = list(data)\n    return sorted(tmp)\n"),
+        (MATPLOTLIB_LIKE_CONTEXT, "plot([1, 2])\nlegend(['x-y'])\n"),
+    ]
+    for ctx, sol in cases:
+        pot = DS1000RuntimeNoErrorPotential(code_context=ctx, timeout_seconds=10.0)
+        assert await pot.complete([sol.encode()]) == 0.0
+        for i, ch in enumerate(sol):
+            if ch == "\n":
+                assert await pot.prefix([sol[: i + 1].encode()]) != float("-inf")
 
 
 @pytest.mark.parametrize("context", [[], list(b"</code>")])


### PR DESCRIPTION
**Problem:**
DS1000RuntimeNoErrorPotential is the expensive critic for DS-1000 SMC: it scores a code prefix 0.0 (keep) or -inf (reject). The old version scored a prefix by running the harnesson the partial solution, but the harness checks the answer variable, so a correct solution still being written across several lines gets rejected at the first line boundary, before it has assigned its answer.

**Fix:**
  - prefix(code) : "can this partial solution still become correct?" Execute only the exec_context lines before the [insert] point, plus the partial solution, and reject only if those statements actually raise at runtime.
  - complete(code): "is the finished solution correct?" Run the full test_execution harness, strictly. Any non-assertion error is -inf.

**How the Runtime potential now works:**
 Every check runs in a sandboxed subprocess (temp cwd, MPLBACKEND=Agg):
  - Incomplete syntax is deferred. An open block/bracket/string or a trailing \ continuation can be completed by the next line, so it returns 0.0. Only genuinely unfixable syntax is rejected.
  - Function-body problems (where the solution is inserted as an indented def f(...): body) are parsed together with the context head.
  - Trailing compound statements aren't executed, the generation may still extend the suite.
  - Environment failures defer instead of rejecting: if the check times out, or a problem's test_execution setup itself fails (e.g. it writes a file the test then reads), we return 0.0 and let complete() make the final call.
  - Terminal markers (</code>, END SOLUTION): once the generation emits one, the solution is frozen, so the prefix applies the full strict check immediately.

An optional warm fork-server execution backend (`use_forkserver=True`) pre-imports the libraries once and forks a child per check.

**Matplotlib**
In matplotlib the harness grades a drawn figure (legend text, axes) rather than a result variable, so inspecting a half-drawn plot raises AttributeError/TypeError. The old potential rejected correct plots mid-draw.

Now, in prefix(): Run only the partial solution's plotting calls against the context head and skip the figure inspection entirely, such that a partial plot is never judged on a legend it hasn't added yet.
